### PR TITLE
Strip BOM from line when skipping header (webvtt)

### DIFF
--- a/webvtt.go
+++ b/webvtt.go
@@ -47,7 +47,8 @@ func ReadFromWebVTT(i io.Reader) (o *Subtitles, err error) {
 	// Skip the header
 	for scanner.Scan() {
 		line = scanner.Text()
-		if len(line) > 0 && line != "WEBVTT" {
+		line = strings.Trim(line, "\xef\xbb\xbf") // strip BOM chars
+		if len(line) > 0 && line == "WEBVTT" {
 			break
 		}
 	}
@@ -59,7 +60,6 @@ func ReadFromWebVTT(i io.Reader) (o *Subtitles, err error) {
 	for scanner.Scan() {
 		// Fetch line
 		line = scanner.Text()
-
 		// Check prefixes
 		switch {
 		// Comment

--- a/webvtt.go
+++ b/webvtt.go
@@ -47,7 +47,7 @@ func ReadFromWebVTT(i io.Reader) (o *Subtitles, err error) {
 	// Skip the header
 	for scanner.Scan() {
 		line = scanner.Text()
-		line = strings.Trim(line, "\xef\xbb\xbf") // strip BOM chars
+		line = strings.TrimPrefix(line, string(BytesBOM))
 		if len(line) > 0 && line == "WEBVTT" {
 			break
 		}


### PR DESCRIPTION
There is a logic bug in skipping the webvtt header:
``line != "WEBVTT"`` should really be ``line == "WEBVTT"``

This worked previously because the header line had UTF-8 byte order mark characters in it.

This PR strips the BOM char before comparison and also fixes the header detection logic.

Edited to add:
Without this fix, processing ascii webvtt files will erroneously drop the first subtitle line.
