### PR TITLE
implement offset time

### DIFF
--- a/ttml.go
+++ b/ttml.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -32,6 +33,9 @@ var ttmlLanguageMapping = astimap.NewMap(ttmlLanguageEnglish, LanguageEnglish).
 
 // TTML regexp
 var ttmlRegexpDurationFrames = regexp.MustCompile("\\:[\\d]+$")
+
+// TTML offset time
+var ttmlRegexpOffsetTime = regexp.MustCompile("(\\d+)(\\.(\\d+))?(h|m|s|ms|f)$")
 
 // TTMLIn represents an input TTML that must be unmarshaled
 // We split it from the output TTML as we can't add strict namespace without breaking retrocompatibility
@@ -204,6 +208,51 @@ type TTMLInDuration struct {
 // - hh:mm:ss:fff (fff being frames)
 func (d *TTMLInDuration) UnmarshalText(i []byte) (err error) {
 	var text = string(i)
+	if matches := ttmlRegexpOffsetTime.FindStringSubmatch(text); matches != nil {
+		metric := matches[4]
+		value, err := strconv.Atoi(matches[1])
+
+		d.d = time.Duration(0)
+
+		var (
+			nsBase       int64
+			fraction     int
+			fractionBase float64
+		)
+		if len(matches[3]) > 0 {
+			fraction, err = strconv.Atoi(matches[3])
+			fractionBase = math.Pow10(len(matches[3]))
+		}
+
+		if err != nil {
+			return err
+		}
+
+		switch metric {
+		case "h":
+			nsBase = time.Hour.Nanoseconds()
+		case "m":
+			nsBase = time.Minute.Nanoseconds()
+		case "s":
+			nsBase = time.Second.Nanoseconds()
+		case "ms":
+			nsBase = time.Millisecond.Nanoseconds()
+		case "f":
+			nsBase = time.Second.Nanoseconds()
+			d.frames = value % d.framerate
+			value = value / d.framerate
+			// TODO, fraction of frames
+		}
+
+		d.d += time.Duration(nsBase * int64(value))
+
+		if fractionBase > 0 {
+			d.d += time.Duration(nsBase * int64(fraction) / int64(fractionBase))
+		}
+
+		return nil
+
+	}
 	if indexes := ttmlRegexpDurationFrames.FindStringIndex(text); indexes != nil {
 		// Parse frames
 		var s = text[indexes[0]+1 : indexes[1]]
@@ -215,6 +264,7 @@ func (d *TTMLInDuration) UnmarshalText(i []byte) (err error) {
 		// Update text
 		text = text[:indexes[0]] + ".000"
 	}
+
 	d.d, err = parseDuration(text, ".", 3)
 	return
 }

--- a/ttml_internal_test.go
+++ b/ttml_internal_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestTTMLDuration(t *testing.T) {
-	// Unmarshal hh:mm:ss.mmm format
+	// Unmarshal hh:mm:ss.mmm format - clock time
 	var d = &TTMLInDuration{}
 	err := d.UnmarshalText([]byte("12:34:56.789"))
 	assert.NoError(t, err)
@@ -31,4 +31,42 @@ func TestTTMLDuration(t *testing.T) {
 	// Duration
 	d.framerate = 8
 	assert.Equal(t, 12*time.Hour+34*time.Minute+56*time.Second+250*time.Millisecond, d.duration())
+
+	// Unmarshal offset time
+	err = d.UnmarshalText([]byte("123h"))
+	assert.Equal(t, 123*time.Hour, d.d)
+	assert.NoError(t, err)
+
+	err = d.UnmarshalText([]byte("123.4h"))
+	assert.Equal(t, 123*time.Hour+4*time.Hour/10, d.d)
+	assert.NoError(t, err)
+
+	err = d.UnmarshalText([]byte("123m"))
+	assert.Equal(t, 123*time.Minute, d.d)
+	assert.NoError(t, err)
+
+	err = d.UnmarshalText([]byte("123.4m"))
+	assert.Equal(t, 123*time.Minute+4*time.Minute/10, d.d)
+	assert.NoError(t, err)
+
+	err = d.UnmarshalText([]byte("123s"))
+	assert.Equal(t, 123*time.Second, d.d)
+	assert.NoError(t, err)
+
+	err = d.UnmarshalText([]byte("123.4s"))
+	assert.Equal(t, 123*time.Second+4*time.Second/10, d.d)
+	assert.NoError(t, err)
+
+	err = d.UnmarshalText([]byte("123ms"))
+	assert.Equal(t, 123*time.Millisecond, d.d)
+	assert.NoError(t, err)
+
+	err = d.UnmarshalText([]byte("123.4ms"))
+	assert.Equal(t, 123*time.Millisecond+4*time.Millisecond/10, d.d)
+	assert.NoError(t, err)
+
+	d.framerate = 25
+	err = d.UnmarshalText([]byte("100f"))
+	assert.Equal(t, 4*time.Second, d.d)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
while parsing TTML, i noticed that you only support clock time format, and no offset format

see: https://www.w3.org/TR/ttaf1-dfxp/#timing-value-timeExpression

this is a "first draft" implementation