### PR TITLE
add support in Open() for upper case extensions

### DIFF
--- a/subtitles.go
+++ b/subtitles.go
@@ -67,7 +67,7 @@ func Open(o Options) (s *Subtitles, err error) {
 	defer f.Close()
 
 	// Parse the content
-	switch filepath.Ext(o.Filename) {
+	switch filepath.Ext(strings.ToLower(o.Filename)) {
 	case ".srt":
 		s, err = ReadFromSRT(f)
 	case ".ssa", ".ass":

--- a/subtitles.go
+++ b/subtitles.go
@@ -574,7 +574,7 @@ func (s Subtitles) Write(dst string) (err error) {
 	defer f.Close()
 
 	// Write the content
-	switch filepath.Ext(dst) {
+	switch filepath.Ext(strings.ToLower(dst)) {
 	case ".srt":
 		err = s.WriteToSRT(f)
 	case ".ssa", ".ass":


### PR DESCRIPTION
I encountered upper case filenames and it was more appropriate to fix the extension dispatcher rather than renaming files, as there is no need to enforce lower case filenames.