### PR TITLE
add colors to webvtt output

### DIFF
--- a/webvtt.go
+++ b/webvtt.go
@@ -295,7 +295,19 @@ func (s Subtitles) WriteToWebVTT(o io.Writer) (err error) {
 
 		// Loop through lines
 		for _, l := range item.Lines {
-			c = append(c, []byte(l.String())...)
+			for _, li := range l.Items {
+				var color string
+				if li.InlineStyle != nil && li.InlineStyle.TTMLColor != "" {
+					color = li.InlineStyle.TTMLColor
+				}
+				if color != "" {
+					c = append(c, []byte("<font color=\""+color+"\">")...)
+				}
+				c = append(c, []byte(li.Text)...)
+				if color != "" {
+					c = append(c, []byte("</font>")...)
+				}
+			}
 			c = append(c, bytesLineSeparator...)
 		}
 


### PR DESCRIPTION
I looked at a TTML to WebVTT converted file from https://transcribefiles.net/other/pages/caption-subtitle-converter.htm, they used the font attribute, so here it is ... Not sure if it's OK to rely on TTMLColor but at least it has the proper value (for now).