### PR TITLE
webvtt,srt: Tolerate edge whitespace (and print line numbers on error)

### DIFF
--- a/srt.go
+++ b/srt.go
@@ -33,10 +33,12 @@ func ReadFromSRT(i io.Reader) (o *Subtitles, err error) {
 
 	// Scan
 	var line string
+	var lineNum int
 	var s = &Item{}
 	for scanner.Scan() {
 		// Fetch line
-		line = scanner.Text()
+		line = strings.TrimSpace(scanner.Text())
+		lineNum++
 
 		// Line contains time boundaries
 		if strings.Contains(line, srtTimeBoundariesSeparator) {
@@ -68,11 +70,11 @@ func ReadFromSRT(i io.Reader) (o *Subtitles, err error) {
 			// Fetch time boundaries
 			boundaries := strings.Split(line, srtTimeBoundariesSeparator)
 			if s.StartAt, err = parseDurationSRT(boundaries[0]); err != nil {
-				err = errors.Wrapf(err, "astisub: parsing srt duration %s failed", boundaries[0])
+				err = errors.Wrapf(err, "astisub: line %d: parsing srt duration %s failed", lineNum, boundaries[0])
 				return
 			}
 			if s.EndAt, err = parseDurationSRT(boundaries[1]); err != nil {
-				err = errors.Wrapf(err, "astisub: parsing srt duration %s failed", boundaries[1])
+				err = errors.Wrapf(err, "astisub: line %d: parsing srt duration %s failed", lineNum, boundaries[1])
 				return
 			}
 

--- a/webvtt.go
+++ b/webvtt.go
@@ -81,7 +81,7 @@ func ReadFromWebVTT(i io.Reader) (o *Subtitles, err error) {
 				// Split on "="
 				var split = strings.Split(part, "=")
 				if len(split) <= 1 {
-					err = fmt.Errorf("astisub: Invalid region style %s", part)
+					err = fmt.Errorf("astisub: line %d: Invalid region style %s", lineNum, part)
 					return
 				}
 

--- a/webvtt.go
+++ b/webvtt.go
@@ -43,9 +43,11 @@ func ReadFromWebVTT(i io.Reader) (o *Subtitles, err error) {
 	o = NewSubtitles()
 	var scanner = bufio.NewScanner(i)
 	var line string
+	var lineNum int
 
 	// Skip the header
 	for scanner.Scan() {
+		lineNum++
 		line = scanner.Text()
 		line = strings.TrimPrefix(line, string(BytesBOM))
 		if len(line) > 0 && strings.Fields(line)[0] == "WEBVTT" {
@@ -59,7 +61,8 @@ func ReadFromWebVTT(i io.Reader) (o *Subtitles, err error) {
 	var comments []string
 	for scanner.Scan() {
 		// Fetch line
-		line = scanner.Text()
+		line = strings.TrimSpace(scanner.Text())
+		lineNum++
 		// Check prefixes
 		switch {
 		// Comment
@@ -126,11 +129,11 @@ func ReadFromWebVTT(i io.Reader) (o *Subtitles, err error) {
 
 			// Parse time boundaries
 			if item.StartAt, err = parseDurationWebVTT(parts[0]); err != nil {
-				err = errors.Wrapf(err, "astisub: parsing webvtt duration %s failed", parts[0])
+				err = errors.Wrapf(err, "astisub: line %d: parsing webvtt duration %s failed", lineNum, parts[0])
 				return
 			}
 			if item.EndAt, err = parseDurationWebVTT(partsRight[0]); err != nil {
-				err = errors.Wrapf(err, "astisub: parsing webvtt duration %s failed", partsRight[0])
+				err = errors.Wrapf(err, "astisub: line %d: parsing webvtt duration %s failed", lineNum, partsRight[0])
 				return
 			}
 
@@ -141,7 +144,7 @@ func ReadFromWebVTT(i io.Reader) (o *Subtitles, err error) {
 					// Split line on ":"
 					var split = strings.Split(partsRight[index], ":")
 					if len(split) <= 1 {
-						err = fmt.Errorf("astisub: Invalid inline style %s", partsRight[index])
+						err = fmt.Errorf("astisub: line %d: Invalid inline style '%s'", lineNum, partsRight[index])
 						return
 					}
 
@@ -155,7 +158,7 @@ func ReadFromWebVTT(i io.Reader) (o *Subtitles, err error) {
 						item.InlineStyle.WebVTTPosition = split[1]
 					case "region":
 						if _, ok := o.Regions[split[1]]; !ok {
-							err = fmt.Errorf("astisub: Unknown region %s", split[1])
+							err = fmt.Errorf("astisub: line %d: Unknown region %s", lineNum, split[1])
 							return
 						}
 						item.Region = o.Regions[split[1]]


### PR DESCRIPTION
Hi! I'm by no means an expert of WebVTT format but this fixed a parsing problem for me. Feel free to reject if it's a bad change, or improve it or whatever you'd like.

PS. It'd be really helpful to output the line number when an error is encountered. Would you be open to a PR for that?