### PR TITLE
srt, ssa, webvtt: adds the ability to parse from strings as opposed to files on disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,25 @@ If **astisub** has been installed properly you can:
 - [x] .ssa/.ass
 - [x] .teletext
 - [ ] .smi
+
+# Parsing from strings
+
+If you are dealing with either `srt`, `ssa`, or `webvtt` subtitles as a slice of strings rather than from files on disk, you can parse them directly with the ParseFrom... functions:
+
+```go
+lines := string[]{"00:01:00.000 --> 00:02:00.000", "Credits"}
+srtSubs := astisub.NewSubtitles()
+err = astisub.ParseFromSRTLines(srtSubs, lines)
+```
+
+```go
+lines := string[]{"[Script Info]", "; Comment 1", "Title: SSA test"}
+ssaSubs := astisub.NewSubtitles()
+err = astisub.ParseFromSSALines(ssaSubs, lines)
+```
+
+```go
+lines := string{"WEBVTT", "NOTE this a nice example", "STYLE"}
+webvttSubs := astisub.NewSubtitles()
+err = astisub.ParseFromWebVTTLines(webvttSubs, lines)
+```

--- a/srt_test.go
+++ b/srt_test.go
@@ -3,13 +3,14 @@ package astisub_test
 import (
 	"bytes"
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/asticode/go-astisub"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSRT(t *testing.T) {
+func TestSRT_Open(t *testing.T) {
 	// Open
 	s, err := astisub.OpenFile("./testdata/example-in.srt")
 	assert.NoError(t, err)
@@ -26,4 +27,18 @@ func TestSRT(t *testing.T) {
 	err = s.WriteToSRT(w)
 	assert.NoError(t, err)
 	assert.Equal(t, string(c), w.String())
+}
+
+func TestSRT_FromLines(t *testing.T) {
+	f, err := os.Open("./testdata/example-in.srt")
+	assert.NoError(t, err)
+	defer f.Close()
+
+	lines, err := astisub.ScanLines(f)
+	assert.NoError(t, err)
+
+	subs := astisub.NewSubtitles()
+	err = astisub.ParseFromSRTLines(subs, lines)
+	assert.NoError(t, err)
+	assertSubtitleItems(t, subs)
 }

--- a/ssa_test.go
+++ b/ssa_test.go
@@ -3,6 +3,7 @@ package astisub_test
 import (
 	"bytes"
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/asticode/go-astikit"
@@ -69,7 +70,7 @@ func assertSSAStyleAttributes(t *testing.T, e, a astisub.StyleAttributes) {
 	}
 }
 
-func TestSSA(t *testing.T) {
+func TestSSA_Open(t *testing.T) {
 	// Open
 	s, err := astisub.OpenFile("./testdata/example-in.ssa")
 	assert.NoError(t, err)
@@ -102,4 +103,18 @@ func TestSSA(t *testing.T) {
 	err = s.WriteToSSA(w)
 	assert.NoError(t, err)
 	assert.Equal(t, string(c), w.String())
+}
+
+func TestSSA_FromLines(t *testing.T) {
+	f, err := os.Open("./testdata/example-in.ssa")
+	assert.NoError(t, err)
+	defer f.Close()
+
+	lines, err := astisub.ScanLines(f)
+	assert.NoError(t, err)
+
+	subs := astisub.NewSubtitles()
+	err = astisub.ParseFromSSALines(subs, lines)
+	assert.NoError(t, err)
+	assertSubtitleItems(t, subs)
 }

--- a/subtitles.go
+++ b/subtitles.go
@@ -1,8 +1,10 @@
 package astisub
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"os"
 	"path/filepath"
@@ -41,6 +43,7 @@ var (
 // Errors
 var (
 	ErrInvalidExtension   = errors.New("astisub: invalid extension")
+	ErrNoSubtitlesToRead  = errors.New("astisub: no subtitles to read")
 	ErrNoSubtitlesToWrite = errors.New("astisub: no subtitles to write")
 )
 
@@ -83,6 +86,19 @@ func Open(o Options) (s *Subtitles, err error) {
 		err = ErrInvalidExtension
 	}
 	return
+}
+
+// ScanLines will scan the content from a file handle into a list of strings
+func ScanLines(i io.Reader) ([]string, error) {
+	var scanner = bufio.NewScanner(i)
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, strings.TrimSpace(scanner.Text()))
+	}
+	if len(lines) == 0 {
+		return nil, ErrNoSubtitlesToRead
+	}
+	return lines, nil
 }
 
 // OpenFile opens a file regardless of other options

--- a/webvtt_test.go
+++ b/webvtt_test.go
@@ -3,13 +3,14 @@ package astisub_test
 import (
 	"bytes"
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/asticode/go-astisub"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestWebVTT(t *testing.T) {
+func TestWebVTT_Open(t *testing.T) {
 	// Open
 	s, err := astisub.OpenFile("./testdata/example-in.vtt")
 	assert.NoError(t, err)
@@ -37,4 +38,18 @@ func TestWebVTT(t *testing.T) {
 	err = s.WriteToWebVTT(w)
 	assert.NoError(t, err)
 	assert.Equal(t, string(c), w.String())
+}
+
+func TestWebVTT_FromLines(t *testing.T) {
+	f, err := os.Open("./testdata/example-in.vtt")
+	assert.NoError(t, err)
+	defer f.Close()
+
+	lines, err := astisub.ScanLines(f)
+	assert.NoError(t, err)
+
+	subs := astisub.NewSubtitles()
+	err = astisub.ParseFromWebVTTLines(subs, lines)
+	assert.NoError(t, err)
+	assertSubtitleItems(t, subs)
 }


### PR DESCRIPTION
Not too long ago I needed the ability to parse subtitles that I was accepting through an upload.

Since go-astisub does a wonderful job parsing and validating a variety of formats, I decided to keep relying on it the way I was already doing so to parse files I already on disk.

Being strapped for time, I decided to simply write the uploads to disk and proceed from there, but now that I've had a bit of time I decided that I should contribute back to project, granted that such a change would even be welcome.

This change centralizes the use of bufio.Scanner in a new function in subtitles to decouple the file reading from the parsing of the resulting lines.