### PR TITLE
Fix a bug parsing lines with only spaces

### DIFF
--- a/testdata/broken-in.vtt
+++ b/testdata/broken-in.vtt
@@ -1,0 +1,2 @@
+ 
+BROKENVTT

--- a/webvtt.go
+++ b/webvtt.go
@@ -47,7 +47,7 @@ func ReadFromWebVTT(i io.Reader) (o *Subtitles, err error) {
 		lineNum++
 		line = scanner.Text()
 		line = strings.TrimPrefix(line, string(BytesBOM))
-		if len(line) > 0 && strings.Fields(line)[0] == "WEBVTT" {
+		if len(line) > 0 && len(strings.Fields(line)) > 0 && strings.Fields(line)[0] == "WEBVTT" {
 			break
 		}
 	}
@@ -123,7 +123,6 @@ func ReadFromWebVTT(i io.Reader) (o *Subtitles, err error) {
 
 			// Reset index
 			index = 0
-			
 			// Split line on time boundaries
 			var parts = strings.Split(line, webvttTimeBoundariesSeparator)
 			// Split line on space to catch inline styles as well

--- a/webvtt.go
+++ b/webvtt.go
@@ -47,7 +47,7 @@ func ReadFromWebVTT(i io.Reader) (o *Subtitles, err error) {
 		lineNum++
 		line = scanner.Text()
 		line = strings.TrimPrefix(line, string(BytesBOM))
-		if len(line) > 0 && len(strings.Fields(line)) > 0 && strings.Fields(line)[0] == "WEBVTT" {
+		if fs := strings.Fields(line); len(fs) > 0 && fs[0] == "WEBVTT" {
 			break
 		}
 	}

--- a/webvtt_test.go
+++ b/webvtt_test.go
@@ -38,3 +38,9 @@ func TestWebVTT(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, string(c), w.String())
 }
+
+func TestBrokenWebVTT(t *testing.T) {
+	// Open bad, broken WebVTT file
+	_, err := astisub.OpenFile("./testdata/broken-in.vtt")
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
Adds a simple test file, `broken-in.vtt`, that starts with a single space character, followed by a newline. In master this file panics with an index out-of-bounds error. This is fixed by checking both that the line length is greater than zero, and that the resulting fields length is also greater than zero.

I've also added a very, very simple test case that can be used to confirm that the current behavior is broken in master.