### PR TITLE
When it reads STL files, it generates an array of ttiblocks in the cl…

### DIFF
--- a/astisub/main.go
+++ b/astisub/main.go
@@ -14,8 +14,8 @@ var (
 	inputPath        = astikit.NewFlagStrings()
 	teletextPage     = flag.Int("p", 0, "the teletext page")
 	outputPath       = flag.String("o", "", "the output path")
-	startTime        = flag.Duration("t", -1, "the start time")
 	syncDuration     = flag.Duration("s", 0, "the sync duration")
+	syncTime         = flag.Duration("t", -1, "the sync time")
 )
 
 func main() {
@@ -88,27 +88,22 @@ func main() {
 		if err = sub.Write(*outputPath); err != nil {
 			log.Fatalf("%s while writing to %s", err, *outputPath)
 		}
-	case "starttime":
-
-		if *startTime < 0 {
-			log.Fatal("Use -t to provide a starttime")
-		}
-
-		// StartTime
-		sub.ChangeStartTime(*startTime)
-
-		// Write
-		if err = sub.Write(*outputPath); err != nil {
-			log.Fatalf("%s while writing to %s", err, *outputPath)
-		}
 	case "sync":
 		// Validate sync duration
-		if *syncDuration == 0 {
-			log.Fatal("Use -s to provide a sync duration")
+		if *syncDuration == 0 && *syncTime < 0 {
+			log.Fatal("Use -s or -t to provide a sync duration or sync time")
 		}
 
-		// Add
-		sub.Add(*syncDuration)
+		if *syncDuration > 0 {
+			// Add
+			sub.Add(*syncDuration)
+		} else if *syncTime > -1 {
+			if len(sub.Items) > 0 {
+				var delay = *syncTime - sub.Items[0].StartAt
+				//Add
+				sub.Add(delay)
+			}
+		}
 
 		// Write
 		if err = sub.Write(*outputPath); err != nil {

--- a/astisub/main.go
+++ b/astisub/main.go
@@ -94,15 +94,11 @@ func main() {
 			log.Fatal("Use -s or -t to provide a sync duration or sync time")
 		}
 
+		// Add
 		if *syncDuration > 0 {
-			// Add
 			sub.Add(*syncDuration)
-		} else if *syncTime > -1 {
-			if len(sub.Items) > 0 {
-				var delay = *syncTime - sub.Items[0].StartAt
-				//Add
-				sub.Add(delay)
-			}
+		} else if *syncTime > -1 && len(sub.Items) > 0 {
+			sub.Add(*syncTime - sub.Items[0].StartAt)
 		}
 
 		// Write
@@ -120,5 +116,4 @@ func main() {
 	default:
 		log.Fatalf("Invalid subcommand %s", cmd)
 	}
-
 }

--- a/astisub/main.go
+++ b/astisub/main.go
@@ -14,6 +14,7 @@ var (
 	inputPath        = astikit.NewFlagStrings()
 	teletextPage     = flag.Int("p", 0, "the teletext page")
 	outputPath       = flag.String("o", "", "the output path")
+	startTime        = flag.Duration("t", -1, "the start time")
 	syncDuration     = flag.Duration("s", 0, "the sync duration")
 )
 
@@ -87,13 +88,26 @@ func main() {
 		if err = sub.Write(*outputPath); err != nil {
 			log.Fatalf("%s while writing to %s", err, *outputPath)
 		}
+	case "starttime":
+
+		if *startTime < 0 {
+			log.Fatal("Use -t to provide a starttime")
+		}
+
+		// StartTime
+		sub.ChangeStartTime(*startTime)
+
+		// Write
+		if err = sub.Write(*outputPath); err != nil {
+			log.Fatalf("%s while writing to %s", err, *outputPath)
+		}
 	case "sync":
 		// Validate sync duration
 		if *syncDuration == 0 {
 			log.Fatal("Use -s to provide a sync duration")
 		}
 
-		// Fragment
+		// Add
 		sub.Add(*syncDuration)
 
 		// Write
@@ -111,4 +125,5 @@ func main() {
 	default:
 		log.Fatalf("Invalid subcommand %s", cmd)
 	}
+
 }

--- a/srt.go
+++ b/srt.go
@@ -33,7 +33,7 @@ func ReadFromSRT(i io.Reader) (o *Subtitles, err error) {
 	// Scan
 	var line string
 	var lineNum int
-	var s = &Item{}
+	var s = &Item{ItemMetadata: newItemMetadata()}
 	for scanner.Scan() {
 		// Fetch line
 		line = strings.TrimSpace(scanner.Text())
@@ -70,10 +70,10 @@ func ReadFromSRT(i io.Reader) (o *Subtitles, err error) {
 			}
 
 			// Init subtitle
-			s = &Item{}
-
+			s = &Item{ItemMetadata: newItemMetadata()}
 			// Fetch Index
-			s.Index, _ = strconv.Atoi(index.String())
+			s.ItemMetadata = &ItemMetadata{}
+			s.ItemMetadata.Index, _ = strconv.Atoi(index.String())
 
 			// Fetch time boundaries
 			boundaries := strings.Split(line, srtTimeBoundariesSeparator)

--- a/srt.go
+++ b/srt.go
@@ -33,7 +33,7 @@ func ReadFromSRT(i io.Reader) (o *Subtitles, err error) {
 	// Scan
 	var line string
 	var lineNum int
-	var s = &Item{ItemMetadata: newItemMetadata()}
+	var s = &Item{Metadata: &ItemMetadata{}}
 	for scanner.Scan() {
 		// Fetch line
 		line = strings.TrimSpace(scanner.Text())
@@ -70,10 +70,9 @@ func ReadFromSRT(i io.Reader) (o *Subtitles, err error) {
 			}
 
 			// Init subtitle
-			s = &Item{ItemMetadata: newItemMetadata()}
+			s = &Item{Metadata: &ItemMetadata{}}
 			// Fetch Index
-			s.ItemMetadata = &ItemMetadata{}
-			s.ItemMetadata.Index, _ = strconv.Atoi(index.String())
+			s.Metadata.Index, _ = strconv.Atoi(index.String())
 
 			// Fetch time boundaries
 			boundaries := strings.Split(line, srtTimeBoundariesSeparator)

--- a/ssa.go
+++ b/ssa.go
@@ -1035,7 +1035,8 @@ func (e *ssaEvent) item(styles map[string]*Style) (i *Item, err error) {
 			SSAMarginVertical: e.marginVertical,
 			SSAMarked:         e.marked,
 		},
-		StartAt: e.start,
+		ItemMetadata: newItemMetadata(),
+		StartAt:      e.start,
 	}
 
 	// Set style

--- a/ssa.go
+++ b/ssa.go
@@ -1035,8 +1035,8 @@ func (e *ssaEvent) item(styles map[string]*Style) (i *Item, err error) {
 			SSAMarginVertical: e.marginVertical,
 			SSAMarked:         e.marked,
 		},
-		ItemMetadata: newItemMetadata(),
-		StartAt:      e.start,
+		Metadata: &ItemMetadata{},
+		StartAt:  e.start,
 	}
 
 	// Set style

--- a/stl.go
+++ b/stl.go
@@ -672,7 +672,7 @@ func newTTIBlock(i *Item, idx int) (t *ttiBlock) {
 		for _, l := range i.Lines {
 			lines = append(lines, l.String())
 		}
-		t.text = []byte(strings.Join(lines, "\n"))
+		t.text = []byte(encodeTextSTL(strings.Join(lines, "\n")))
 	}
 	return
 }

--- a/stl.go
+++ b/stl.go
@@ -698,20 +698,15 @@ func (t *ttiBlock) bytes(g *gsiBlock) (o []byte) {
 	o = append(o, byte(uint8(t.subtitleGroupNumber))) // Subtitle group number
 	var b = make([]byte, 2)
 	binary.LittleEndian.PutUint16(b, uint16(t.subtitleNumber))
-	o = append(o, b...)                                                  // Subtitle number
-	o = append(o, byte(uint8(t.extensionBlockNumber)))                   // Extension block number
-	o = append(o, t.cumulativeStatus)                                    // Cumulative status
-	o = append(o, formatDurationSTLBytes(t.timecodeIn, g.framerate)...)  // Timecode in
-	o = append(o, formatDurationSTLBytes(t.timecodeOut, g.framerate)...) // Timecode out
-	o = append(o, byte(uint8(t.verticalPosition)))                       // Vertical position
-	o = append(o, t.justificationCode)                                   // Justification code
-	o = append(o, t.commentFlag)                                         // Comment flag
-	//if text has 112 characters, copy directly
-	if len(t.text) == 112 {
-		o = append(o, t.text...)
-	} else {
-		o = append(o, astikit.BytesPad(encodeTextSTL(string(t.text)), '\x8f', 112, astikit.PadRight, astikit.PadCut)...) // Text field
-	}
+	o = append(o, b...)                                                                       // Subtitle number
+	o = append(o, byte(uint8(t.extensionBlockNumber)))                                        // Extension block number
+	o = append(o, t.cumulativeStatus)                                                         // Cumulative status
+	o = append(o, formatDurationSTLBytes(t.timecodeIn, g.framerate)...)                       // Timecode in
+	o = append(o, formatDurationSTLBytes(t.timecodeOut, g.framerate)...)                      // Timecode out
+	o = append(o, byte(uint8(t.verticalPosition)))                                            // Vertical position
+	o = append(o, t.justificationCode)                                                        // Justification code
+	o = append(o, t.commentFlag)                                                              // Comment flag
+	o = append(o, astikit.BytesPad(t.text, '\x8f', 112, astikit.PadRight, astikit.PadCut)...) // Text field
 	return
 }
 

--- a/stl.go
+++ b/stl.go
@@ -857,7 +857,6 @@ func (s Subtitles) WriteToSTL(o io.Writer) (err error) {
 			return
 		}
 	}
-
 	return
 }
 

--- a/stl.go
+++ b/stl.go
@@ -261,8 +261,10 @@ func ReadFromSTL(i io.Reader) (o *Subtitles, err error) {
 		i.Metadata.STLSubtitleGroupNumber = &t.subtitleGroupNumber
 		i.Metadata.STLText = &t.text
 
-		// Append item
-		o.Items = append(o.Items, i)
+		if len(i.Lines) > 0 {
+			// Append item
+			o.Items = append(o.Items, i)
+		}
 	}
 	return
 }

--- a/subtitles.go
+++ b/subtitles.go
@@ -386,7 +386,6 @@ func (s *Subtitles) Add(d time.Duration) {
 	for idx := 0; idx < len(s.Items); idx++ {
 		s.Items[idx].EndAt += d
 		s.Items[idx].StartAt += d
-
 		if s.Items[idx].EndAt <= 0 && s.Items[idx].StartAt <= 0 {
 			s.Items = append(s.Items[:idx], s.Items[idx+1:]...)
 			idx--

--- a/subtitles.go
+++ b/subtitles.go
@@ -184,26 +184,27 @@ func (c *Color) WebVTTString() string {
 
 }
 
-// WebVTTPosition Webvtt Justification From STL
-func (sv *stlVerticalPosition) WebVTTPosition() string {
-	switch *sv {
+// WebVTTLine  WebVTT Vertical Position From STL
+func (sv *stlVerticalPosition) WebVTTLine() string {	
+	if *sv < 3 { //top
+		return "20%"
+	} else if *sv <= 12 { //(23/2)+1	//middle
+		return "50%"
+	} else {
+		return ""
+	}
+	
+
+}
+
+// WebVTTPosition WebVTT Jusitification from STL
+func (sj *stlJustificationCode) WebVTTPosition() string {	
+	switch *sj {
 	case stlJustificationCodeLeftJustifiedText:
 		return "20%" //left
 	case stlJustificationCodeRightJustifiedText:
 		return "80%" //right
 	default:
-		return ""
-	}
-
-}
-
-// WebVTTLine WebVTT Line Vertical Position from STL
-func (sj *stlJustificationCode) WebVTTLine() string {
-	if *sj < 3 { //top
-		return "20%"
-	} else if *sj <= 12 { //(23/2)+1	//middle
-		return "50%"
-	} else {
 		return ""
 	}
 }
@@ -291,11 +292,11 @@ type StyleAttributes struct {
 func (sa *StyleAttributes) propagateSSAAttributes() {}
 
 func (sa *StyleAttributes) propagateSTLAttributes() {
-	if sa.STLJustificationCode != nil {
-		sa.WebVTTLine = sa.STLJustificationCode.WebVTTLine()
-	}
 	if sa.STLVerticalPostion != nil {
-		sa.WebVTTPosition = sa.STLVerticalPostion.WebVTTPosition()
+		sa.WebVTTLine = sa.STLVerticalPostion.WebVTTLine()
+	}
+	if sa.STLJustificationCode != nil {
+		sa.WebVTTPosition = sa.STLJustificationCode.WebVTTPosition()
 	}
 }
 

--- a/subtitles.go
+++ b/subtitles.go
@@ -93,11 +93,10 @@ func OpenFile(filename string) (*Subtitles, error) {
 
 // Subtitles represents an ordered list of items with formatting
 type Subtitles struct {
-	Items        []*Item
-	Metadata     *Metadata
-	Regions      map[string]*Region
-	Styles       map[string]*Style
-	ItemMetadata *ItemMetadata
+	Items    []*Item
+	Metadata *Metadata
+	Regions  map[string]*Region
+	Styles   map[string]*Style
 }
 
 // NewSubtitles creates new subtitles
@@ -110,14 +109,14 @@ func NewSubtitles() *Subtitles {
 
 // Item represents a text to show between 2 time boundaries with formatting
 type Item struct {
-	Comments     []string
-	EndAt        time.Duration
-	InlineStyle  *StyleAttributes
-	ItemMetadata *ItemMetadata
-	Lines        []Line
-	Region       *Region
-	StartAt      time.Duration
-	Style        *Style
+	Comments    []string
+	EndAt       time.Duration
+	InlineStyle *StyleAttributes
+	Lines       []Line
+	Metadata    *ItemMetadata
+	Region      *Region
+	StartAt     time.Duration
+	Style       *Style
 }
 
 // String implements the Stringer interface
@@ -340,22 +339,11 @@ type Metadata struct {
 //ItemMetadata represents specific item metadata
 type ItemMetadata struct {
 	Index                   int
-	STLCommentFlag          byte
-	STLCumulativeStatus     byte
-	STLExtensionBlockNumber int
-	STLSubtitleGroupNumber  int
-	STLText                 []byte
-}
-
-func newItemMetadata() (im *ItemMetadata) {
-	//Init
-	im = &ItemMetadata{
-		STLCommentFlag:          stlCommentFlagTextContainsSubtitleData,
-		STLCumulativeStatus:     stlCumulativeStatusSubtitleNotPartOfACumulativeSet,
-		STLExtensionBlockNumber: 255,
-		STLSubtitleGroupNumber:  0,
-	}
-	return
+	STLCommentFlag          *byte
+	STLCumulativeStatus     *byte
+	STLExtensionBlockNumber *int
+	STLSubtitleGroupNumber  *int
+	STLText                 *[]byte
 }
 
 // Region represents a subtitle's region
@@ -407,6 +395,15 @@ func (s *Subtitles) Add(d time.Duration) {
 			s.Items[idx].StartAt = time.Duration(0)
 		}
 	}
+}
+
+// Add adds a duration to each time boundaries. As in the time package, duration can be negative.
+func (s *Subtitles) ChangeStartTime(starttime time.Duration) {
+	if len(s.Items) > 0 {
+		var delay = starttime - s.Items[0].StartAt
+		s.Add(delay)
+	}
+
 }
 
 // Duration returns the subtitles duration
@@ -471,7 +468,7 @@ func (s *Subtitles) Fragment(f time.Duration) {
 		//   fragment start at        fragment end at
 		for i, sub := range s.Items {
 			// Init
-			var newSub = &Item{ItemMetadata: newItemMetadata()}
+			var newSub = &Item{}
 			*newSub = *sub
 
 			// A switch is more readable here

--- a/subtitles.go
+++ b/subtitles.go
@@ -185,7 +185,7 @@ func (c *Color) WebVTTString() string {
 }
 
 // WebVTTLine  WebVTT Vertical Position From STL
-func (sv *stlVerticalPosition) WebVTTLine() string {	
+func (sv *stlVerticalPosition) WebVTTLine() string {
 	if *sv < 3 { //top
 		return "20%"
 	} else if *sv <= 12 { //(23/2)+1	//middle
@@ -193,12 +193,10 @@ func (sv *stlVerticalPosition) WebVTTLine() string {
 	} else {
 		return ""
 	}
-	
-
 }
 
 // WebVTTPosition WebVTT Jusitification from STL
-func (sj *stlJustificationCode) WebVTTPosition() string {	
+func (sj *stlJustificationCode) WebVTTPosition() string {
 	switch *sj {
 	case stlJustificationCodeLeftJustifiedText:
 		return "20%" //left
@@ -396,15 +394,6 @@ func (s *Subtitles) Add(d time.Duration) {
 			s.Items[idx].StartAt = time.Duration(0)
 		}
 	}
-}
-
-// Add adds a duration to each time boundaries. As in the time package, duration can be negative.
-func (s *Subtitles) ChangeStartTime(starttime time.Duration) {
-	if len(s.Items) > 0 {
-		var delay = starttime - s.Items[0].StartAt
-		s.Add(delay)
-	}
-
 }
 
 // Duration returns the subtitles duration

--- a/teletext.go
+++ b/teletext.go
@@ -859,7 +859,7 @@ func parseTeletextRow(i *Item, d decoder, fs func() styler, row []byte) {
 	// Loop through columns
 	var l = Line{}
 	var li = LineItem{InlineStyle: &StyleAttributes{}}
-	var started bool
+
 	var s styler
 	for _, v := range row {
 		// Create specific styler
@@ -887,10 +887,6 @@ func parseTeletextRow(i *Item, d decoder, fs func() styler, row []byte) {
 			color = ColorCyan
 		case 0x7:
 			color = ColorWhite
-		case 0xa:
-			started = false
-		case 0xb:
-			started = true
 		case 0xc:
 			doubleHeight = astikit.BoolPtr(false)
 			doubleSize = astikit.BoolPtr(false)
@@ -913,16 +909,14 @@ func parseTeletextRow(i *Item, d decoder, fs func() styler, row []byte) {
 			if color != li.InlineStyle.TeletextColor || doubleHeight != li.InlineStyle.TeletextDoubleHeight ||
 				doubleSize != li.InlineStyle.TeletextDoubleSize || doubleWidth != li.InlineStyle.TeletextDoubleWidth ||
 				(s != nil && s.hasChanged(li.InlineStyle)) {
-				// Line has started
-				if started {
-					// Append line item
-					appendTeletextLineItem(&l, li, s)
 
-					// Create new line item
-					sa := &StyleAttributes{}
-					*sa = *li.InlineStyle
-					li = LineItem{InlineStyle: sa}
-				}
+				// Append line item
+				appendTeletextLineItem(&l, li, s)
+
+				// Create new line item
+				sa := &StyleAttributes{}
+				*sa = *li.InlineStyle
+				li = LineItem{InlineStyle: sa}
 
 				// Update style attributes
 				if color != nil && color != li.InlineStyle.TeletextColor {
@@ -941,7 +935,7 @@ func parseTeletextRow(i *Item, d decoder, fs func() styler, row []byte) {
 					s.update(li.InlineStyle)
 				}
 			}
-		} else if started {
+		} else {
 			// Append text
 			li.Text += string(d.decode(v))
 		}

--- a/teletext.go
+++ b/teletext.go
@@ -830,8 +830,9 @@ func (p *teletextPage) parse(s *Subtitles, d *teletextCharacterDecoder, firstTim
 
 	// Create item
 	i := &Item{
-		EndAt:   p.end.Sub(firstTime),
-		StartAt: p.start.Sub(firstTime),
+		EndAt:        p.end.Sub(firstTime),
+		ItemMetadata: newItemMetadata(),
+		StartAt:      p.start.Sub(firstTime),
 	}
 
 	// Loop through rows

--- a/teletext.go
+++ b/teletext.go
@@ -861,7 +861,6 @@ func parseTeletextRow(i *Item, d decoder, fs func() styler, row []byte) {
 	var l = Line{}
 	var li = LineItem{InlineStyle: &StyleAttributes{}}
 	var started bool
-
 	var s styler
 	for _, v := range row {
 		// Create specific styler

--- a/teletext.go
+++ b/teletext.go
@@ -943,7 +943,7 @@ func parseTeletextRow(i *Item, d decoder, fs func() styler, row []byte) {
 					s.update(li.InlineStyle)
 				}
 			}
-		} else {
+		} else if started {
 			// Append text
 			li.Text += string(d.decode(v))
 		}

--- a/ttml.go
+++ b/ttml.go
@@ -350,9 +350,10 @@ func ReadFromTTML(i io.Reader) (o *Subtitles, err error) {
 		ts.Begin.framerate = ttml.Framerate
 		ts.End.framerate = ttml.Framerate
 		var s = &Item{
-			EndAt:       ts.End.duration(),
-			InlineStyle: ts.TTMLInStyleAttributes.styleAttributes(),
-			StartAt:     ts.Begin.duration(),
+			EndAt:        ts.End.duration(),
+			InlineStyle:  ts.TTMLInStyleAttributes.styleAttributes(),
+			ItemMetadata: newItemMetadata(),
+			StartAt:      ts.Begin.duration(),
 		}
 
 		// Add region

--- a/ttml.go
+++ b/ttml.go
@@ -350,10 +350,10 @@ func ReadFromTTML(i io.Reader) (o *Subtitles, err error) {
 		ts.Begin.framerate = ttml.Framerate
 		ts.End.framerate = ttml.Framerate
 		var s = &Item{
-			EndAt:        ts.End.duration(),
-			InlineStyle:  ts.TTMLInStyleAttributes.styleAttributes(),
-			ItemMetadata: newItemMetadata(),
-			StartAt:      ts.Begin.duration(),
+			EndAt:       ts.End.duration(),
+			InlineStyle: ts.TTMLInStyleAttributes.styleAttributes(),
+			Metadata:    &ItemMetadata{},
+			StartAt:     ts.Begin.duration(),
 		}
 
 		// Add region

--- a/webvtt.go
+++ b/webvtt.go
@@ -299,7 +299,16 @@ func (s Subtitles) WriteToWebVTT(o io.Writer) (err error) {
 
 		// Loop through lines
 		for _, l := range item.Lines {
+			var closectag bool
+			if l.Items != nil && len(l.Items) > 0 && l.Items[0].InlineStyle != nil &&
+				l.Items[0].InlineStyle.WebVTTColor != "" {
+				c = append(c, []byte(l.Items[0].InlineStyle.WebVTTColor)...)
+				closectag = true
+			}
 			c = append(c, []byte(l.String())...)
+			if closectag {
+				c = append(c, bytesClosectag...)
+			}
 			c = append(c, bytesLineSeparator...)
 		}
 

--- a/webvtt.go
+++ b/webvtt.go
@@ -53,7 +53,7 @@ func ReadFromWebVTT(i io.Reader) (o *Subtitles, err error) {
 	}
 
 	// Scan
-	var item = &Item{}
+	var item = &Item{ItemMetadata: newItemMetadata()}
 	var blockName string
 	var comments []string
 	var index int
@@ -116,11 +116,12 @@ func ReadFromWebVTT(i io.Reader) (o *Subtitles, err error) {
 
 			// Init new item
 			item = &Item{
-				Comments:    comments,
-				Index:       index,
-				InlineStyle: &StyleAttributes{},
+				Comments:     comments,
+				InlineStyle:  &StyleAttributes{},
+				ItemMetadata: newItemMetadata(),
 			}
 
+			item.ItemMetadata.Index = index
 			// Reset index
 			index = 0
 			// Split line on time boundaries

--- a/webvtt.go
+++ b/webvtt.go
@@ -191,7 +191,6 @@ func ReadFromWebVTT(i io.Reader) (o *Subtitles, err error) {
 				// This is the ID
 				index, _ = strconv.Atoi(line)
 			}
-			item.InlineStyle.propagateWebVTTAttributes()
 		}
 	}
 	return

--- a/webvtt.go
+++ b/webvtt.go
@@ -53,7 +53,7 @@ func ReadFromWebVTT(i io.Reader) (o *Subtitles, err error) {
 	}
 
 	// Scan
-	var item = &Item{ItemMetadata: newItemMetadata()}
+	var item = &Item{Metadata: &ItemMetadata{}}
 	var blockName string
 	var comments []string
 	var index int
@@ -116,12 +116,12 @@ func ReadFromWebVTT(i io.Reader) (o *Subtitles, err error) {
 
 			// Init new item
 			item = &Item{
-				Comments:     comments,
-				InlineStyle:  &StyleAttributes{},
-				ItemMetadata: newItemMetadata(),
+				Comments:    comments,
+				InlineStyle: &StyleAttributes{},
+				Metadata:    &ItemMetadata{},
 			}
 
-			item.ItemMetadata.Index = index
+			item.Metadata.Index = index
 			// Reset index
 			index = 0
 			// Split line on time boundaries
@@ -172,7 +172,6 @@ func ReadFromWebVTT(i io.Reader) (o *Subtitles, err error) {
 				}
 			}
 			item.InlineStyle.propagateWebVTTAttributes()
-
 			// Reset comments
 			comments = []string{}
 
@@ -192,6 +191,7 @@ func ReadFromWebVTT(i io.Reader) (o *Subtitles, err error) {
 				// This is the ID
 				index, _ = strconv.Atoi(line)
 			}
+			item.InlineStyle.propagateWebVTTAttributes()
 		}
 	}
 	return


### PR DESCRIPTION
…ass Subtitles. If we use sync from a stl filel, it changes starttimes in ttiblocks array and it saves the file from ttiblocks instead of Items, mantaining lines properties.

It takes account colour and text position converting from STL to VTT.
If creattion date and modification date of STL are empty, it continues conversion from STL to VTT