### PR TITLE
Implement tick duration support for TTML subtitles

### DIFF
--- a/ttml.go
+++ b/ttml.go
@@ -38,13 +38,13 @@ var (
 // TTMLIn represents an input TTML that must be unmarshaled
 // We split it from the output TTML as we can't add strict namespace without breaking retrocompatibility
 type TTMLIn struct {
-	Tickrate  int              `xml:"tickRate,attr"`
 	Framerate int              `xml:"frameRate,attr"`
 	Lang      string           `xml:"lang,attr"`
 	Metadata  TTMLInMetadata   `xml:"head>metadata"`
 	Regions   []TTMLInRegion   `xml:"head>layout>region"`
 	Styles    []TTMLInStyle    `xml:"head>styling>style"`
 	Subtitles []TTMLInSubtitle `xml:"body>div>p"`
+	Tickrate  int              `xml:"tickRate,attr"`
 	XMLName   xml.Name         `xml:"tt"`
 }
 
@@ -352,8 +352,8 @@ func ReadFromTTML(i io.Reader) (o *Subtitles, err error) {
 	// Loop through subtitles
 	for _, ts := range ttml.Subtitles {
 		// Init item
-		ts.Begin.tickrate = ttml.Tickrate
 		ts.Begin.framerate = ttml.Framerate
+		ts.Begin.tickrate = ttml.Tickrate
 		ts.End.framerate = ttml.Framerate
 		ts.End.tickrate = ttml.Tickrate
 

--- a/ttml_internal_test.go
+++ b/ttml_internal_test.go
@@ -69,4 +69,11 @@ func TestTTMLDuration(t *testing.T) {
 	err = d.UnmarshalText([]byte("100f"))
 	assert.Equal(t, 4*time.Second, d.d)
 	assert.NoError(t, err)
+
+	// Tick rate duration
+	d.tickrate = 2
+	d.framerate = 0 // Framerate not set
+	err = d.UnmarshalText([]byte("5000t"))
+	assert.Equal(t, time.Duration(2500 * time.Second.Nanoseconds()), d.duration())
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
I tested it with some examples and it should work. For instance, you can take the example Netflix subtitles:

```
<?xml version="1.0" encoding="UTF-8"?>
<tt xmlns="http://www.w3.org/ns/ttml" xmlns:tt="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" xmlns:tts="http://www.w3.org/ns/ttml#styling" ttp:tickRate="10000000" ttp:version="2" xml:lang="ja">
 <head>
  <styling>
   <initial tts:backgroundColor="transparent" tts:color="white" tts:fontSize="6.000vh"/>
   <style xml:id="style0" tts:textAlign="center"/>
   <style xml:id="style1" tts:textAlign="start"/>
   <style xml:id="style2" tts:ruby="container" tts:rubyPosition="auto"/>
   <style xml:id="style3" tts:ruby="base"/>
   <style xml:id="style4" tts:ruby="text"/>
   <style xml:id="style5" tts:ruby="text"/>
  </styling>
  <layout>
   <region xml:id="region0" tts:displayAlign="after"/>
  </layout>
  </head>
 <body xml:space="preserve">
  <div>
   <p xml:id="subtitle1" begin="18637368750t" end="18676157500t" region="region0" style="style0"><span style="style1">テソプ<span style="style2"><span style="style3">の所だ</span><span style="style4">カン食ン</span></span>食おう<br/><span style="style2"><span style="style3">江陵</span><span style="style5">カンヌン</span></span>で刺身でも食おう</span></p>
  </div>
 </body>
</tt>
```

(Found here: https://netflixtechblog.com/implementing-japanese-subtitles-on-netflix-c165fbe61989 )