### PR TITLE
Print out the wrong number of lines when an error occurs

### DIFF
--- a/srt.go
+++ b/srt.go
@@ -39,6 +39,9 @@ func ReadFromSRT(i io.Reader) (o *Subtitles, err error) {
 		line = strings.TrimSpace(scanner.Text())
 		lineNum++
 
+		// Print out the wrong number of lines
+		fmt.Errorf("error in the (%v) line", lineNum)
+
 		// Remove BOM header
 		if lineNum == 1 {
 			line = strings.TrimPrefix(line, string(BytesBOM))


### PR DESCRIPTION
Today, my colleague and I encountered a panic and found that an error occurred while translating the file, and the error was located in srt.go. After investigation, there was an error in a certain line of the file, but it was not printed in srt.go. Therefore, we hope to add a line of code to print the number of wrong lines in srt.go to facilitate the location of errors.