### PR TITLE
Print out the wrong number of lines when an error occurs

### DIFF
--- a/srt.go
+++ b/srt.go
@@ -46,6 +46,12 @@ func ReadFromSRT(i io.Reader) (o *Subtitles, err error) {
 
 		// Line contains time boundaries
 		if strings.Contains(line, srtTimeBoundariesSeparator) {
+			// Return the wrong number of rows
+			if len(s.Lines) == 0 {
+				err = fmt.Errorf("astisub: line %d: no lines", lineNum)
+				return
+			}
+
 			// Remove last item of previous subtitle since it's the index
 			index := s.Lines[len(s.Lines)-1]
 			s.Lines = s.Lines[:len(s.Lines)-1]


### PR DESCRIPTION
Today, my colleague and I encountered a panic and found that an error occurred while translating the file, and the error was located in srt.go. After investigation, there was an error in a certain line of the file, but it was not printed in srt.go.For example,our srt file format has a timeline and corresponding subtitles, but if there are multiple lines of subtitles, it will panic. Under normal circumstances, it should be an error and return an error and then print the log, not panic.Therefore, we hope to add a line of code to print the number of wrong lines in srt.go to facilitate the location of errors.