### PR TITLE
Add STLTimecodeStartOfProgramme to Metadata

### DIFF
--- a/stl.go
+++ b/stl.go
@@ -207,6 +207,7 @@ func ReadFromSTL(i io.Reader) (o *Subtitles, err error) {
 		STLPublisher:                                        g.publisher,
 		STLRevisionDate:                                     &g.revisionDate,
 		STLSubtitleListReferenceCode:                        g.subtitleListReferenceCode,
+		STLTimecodeStartOfProgramme:                         g.timecodeStartOfProgramme,
 		Title:                                               g.originalProgramTitle,
 	}
 	if v, ok := stlLanguageMapping.Get(g.languageCode); ok {
@@ -342,6 +343,7 @@ func newGSIBlock(s Subtitles) (g *gsiBlock) {
 		revisionDate:                                     Now(),
 		subtitleListReferenceCode:                        "",
 		timecodeStatus:                                   stlTimecodeStatusIntendedForUse,
+		timecodeStartOfProgramme:                         0,
 		totalNumberOfDisks:                               1,
 		totalNumberOfSubtitleGroups:                      1,
 		totalNumberOfSubtitles:                           len(s.Items),
@@ -371,6 +373,7 @@ func newGSIBlock(s Subtitles) (g *gsiBlock) {
 			g.revisionDate = *s.Metadata.STLRevisionDate
 		}
 		g.subtitleListReferenceCode = s.Metadata.STLSubtitleListReferenceCode
+		g.timecodeStartOfProgramme = s.Metadata.STLTimecodeStartOfProgramme
 	}
 
 	// Timecode first in cue

--- a/subtitles.go
+++ b/subtitles.go
@@ -285,6 +285,7 @@ type Metadata struct {
 	STLPublisher                                        string
 	STLRevisionDate                                     *time.Time
 	STLSubtitleListReferenceCode                        string
+	STLTimecodeStartOfProgramme                         time.Duration
 	Title                                               string
 	TTMLCopyright                                       string
 }


### PR DESCRIPTION
When reading STL files, astisub subtracts the value of timecodeStartOfProgramme from all Item timecodes. In our project we need to know if this has happend, and what this value was. 