### PR TITLE
stl: have vertical position no lower than 1

### DIFF
--- a/stl.go
+++ b/stl.go
@@ -666,7 +666,11 @@ func newTTIBlock(i *Item, idx int) (t *ttiBlock) {
 
 func stlVerticalPositionFromStyle(sa *StyleAttributes) int {
 	if sa != nil && sa.STLPosition != nil {
-		return sa.STLPosition.VerticalPosition
+		vp := sa.STLPosition.VerticalPosition
+		if vp < 1 {
+			vp = 1
+		}
+		return vp
 	} else {
 		return 20
 	}


### PR DESCRIPTION
According to EBU 3264 (https://tech.ebu.ch/docs/tech/tech3264.pdf):
```
For teletext subtitles, VP contains a value in the range 1-23 decimal (01h-17h)
corresponding to theteletext row number of the first subtitle row.

For in-vision subtitles, VP contains a value in the range 0..NN decimal,
where NN is the maximumnumber of rows indicated in the MNR field in the GSI block
(Note: NN cannot be greater than 99 decimal(63h)).
This VP represents the number of row locations from the top of the screen to the first subtitle row.
```
My motivation: some STL subs I encountered had an erroneous zero vertical position.