### PR TITLE
Add STL option to ignore start of programme timecode

### DIFF
--- a/stl.go
+++ b/stl.go
@@ -213,11 +213,10 @@ func ReadFromSTL(i io.Reader, opts STLOptions) (o *Subtitles, err error) {
 		STLPublisher:                                        g.publisher,
 		STLRevisionDate:                                     &g.revisionDate,
 		STLSubtitleListReferenceCode:                        g.subtitleListReferenceCode,
-		STLTimecodeStartOfProgramme:                         g.timecodeStartOfProgramme,
 		Title:                                               g.originalProgramTitle,
 	}
-	if opts.IgnoreTimecodeStartOfProgramme {
-		o.Metadata.STLTimecodeStartOfProgramme = 0
+	if !opts.IgnoreTimecodeStartOfProgramme {
+		o.Metadata.STLTimecodeStartOfProgramme = g.timecodeStartOfProgramme
 	}
 	if v, ok := stlLanguageMapping.Get(g.languageCode); ok {
 		o.Metadata.Language = v.(string)

--- a/stl.go
+++ b/stl.go
@@ -170,8 +170,14 @@ type STLPosition struct {
 	Rows             int
 }
 
+// STLOptions represents STL parsing options
+type STLOptions struct {
+	// IgnoreTimecodeStartOfProgramme - set STLTimecodeStartOfProgramme to zero before parsing
+	IgnoreTimecodeStartOfProgramme bool
+}
+
 // ReadFromSTL parses an .stl content
-func ReadFromSTL(i io.Reader) (o *Subtitles, err error) {
+func ReadFromSTL(i io.Reader, opts STLOptions) (o *Subtitles, err error) {
 	// Init
 	o = NewSubtitles()
 
@@ -209,6 +215,9 @@ func ReadFromSTL(i io.Reader) (o *Subtitles, err error) {
 		STLSubtitleListReferenceCode:                        g.subtitleListReferenceCode,
 		STLTimecodeStartOfProgramme:                         g.timecodeStartOfProgramme,
 		Title:                                               g.originalProgramTitle,
+	}
+	if opts.IgnoreTimecodeStartOfProgramme {
+		o.Metadata.STLTimecodeStartOfProgramme = 0
 	}
 	if v, ok := stlLanguageMapping.Get(g.languageCode); ok {
 		o.Metadata.Language = v.(string)

--- a/subtitles.go
+++ b/subtitles.go
@@ -3,13 +3,14 @@ package astisub
 import (
 	"errors"
 	"fmt"
-	"github.com/asticode/go-astikit"
 	"math"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/asticode/go-astikit"
 )
 
 // Bytes
@@ -54,6 +55,7 @@ var Now = func() time.Time {
 type Options struct {
 	Filename string
 	Teletext TeletextOptions
+	STL      STLOptions
 }
 
 // Open opens a subtitle reader based on options
@@ -73,7 +75,7 @@ func Open(o Options) (s *Subtitles, err error) {
 	case ".ssa", ".ass":
 		s, err = ReadFromSSA(f)
 	case ".stl":
-		s, err = ReadFromSTL(f)
+		s, err = ReadFromSTL(f, o.STL)
 	case ".ts":
 		s, err = ReadFromTeletext(f, o.Teletext)
 	case ".ttml":


### PR DESCRIPTION
Solves #49 using an option parameter in STLOptions similar to what is available for Teletext.