### PR TITLE
add a debug option to astisub to output informations on a subtitle

### DIFF
--- a/astisub/main.go
+++ b/astisub/main.go
@@ -15,6 +15,7 @@ var (
 	teletextPage     = flag.Int("p", 0, "the teletext page")
 	outputPath       = flag.String("o", "", "the output path")
 	syncDuration     = flag.Duration("s", 0, "the sync duration")
+	debug            = flag.Bool("d", false, "show debug informations")
 )
 
 func main() {
@@ -36,7 +37,7 @@ func main() {
 	// Open first input path
 	var sub *astisub.Subtitles
 	var err error
-	if sub, err = astisub.Open(astisub.Options{Filename: (*inputPath.Slice)[0], Teletext: astisub.TeletextOptions{Page: *teletextPage}}); err != nil {
+	if sub, err = astisub.Open(astisub.Options{Filename: (*inputPath.Slice)[0], Teletext: astisub.TeletextOptions{Page: *teletextPage}, Debug: *debug}); err != nil {
 		log.Fatalf("%s while opening %s", err, (*inputPath.Slice)[0])
 	}
 

--- a/stl.go
+++ b/stl.go
@@ -200,6 +200,15 @@ func ReadFromSTL(i io.Reader, opts STLOptions) (o *Subtitles, err error) {
 		return
 	}
 
+	if Debug.enabled {
+		fmt.Printf("STL:GSIBlock\n")
+		fmt.Printf("STL:  DisplayStandardCode:0x%x\n", g.displayStandardCode)
+		fmt.Printf("STL:  TotalNumberOfTTIBlocks:%d\n", g.totalNumberOfTTIBlocks)
+		fmt.Printf("STL:  TotalNumberOfSubtitleGroups:%d\n", g.totalNumberOfSubtitleGroups)
+		fmt.Printf("STL:  TotalNumberOfSubtitles:%d\n", g.totalNumberOfSubtitles)
+		fmt.Printf("STL:\n")
+	}
+
 	// Create character handler
 	var ch *stlCharacterHandler
 	if ch, err = newSTLCharacterHandler(g.characterCodeTableNumber); err != nil {
@@ -284,6 +293,20 @@ func ReadFromSTL(i io.Reader, opts STLOptions) (o *Subtitles, err error) {
 		// Append item
 		o.Items = append(o.Items, i)
 
+		if Debug.enabled {
+			warnTime := "   "
+			if i.StartAt > i.EndAt || Debug.prevEnd > i.StartAt {
+				warnTime = " ! "
+				Debug.numErrors++
+			}
+			fmt.Printf("STL: #%04d%s%09.3f - %09.3f%svp=%d\tlines=%d %s\n",
+				t.subtitleNumber, warnTime, i.StartAt.Seconds(), i.EndAt.Seconds(),
+				warnTime, t.verticalPosition, len(i.Lines), i.Lines)
+			Debug.prevEnd = i.EndAt
+		}
+	}
+	if Debug.enabled {
+		fmt.Printf("STL: %d error(s)\n", Debug.numErrors)
 	}
 	return
 }

--- a/subtitles.go
+++ b/subtitles.go
@@ -13,6 +13,13 @@ import (
 	"github.com/asticode/go-astikit"
 )
 
+// Debug contains debug params
+var Debug struct {
+	enabled   bool          // should we output debug
+	numErrors int           // error counter
+	prevEnd   time.Duration // end time of previous sub
+}
+
 // Bytes
 var (
 	BytesBOM           = []byte{239, 187, 191}
@@ -56,6 +63,7 @@ type Options struct {
 	Filename string
 	Teletext TeletextOptions
 	STL      STLOptions
+	Debug    bool
 }
 
 // Open opens a subtitle reader based on options
@@ -68,6 +76,7 @@ func Open(o Options) (s *Subtitles, err error) {
 	}
 	defer f.Close()
 
+	Debug.enabled = o.Debug
 	// Parse the content
 	switch filepath.Ext(strings.ToLower(o.Filename)) {
 	case ".srt":


### PR DESCRIPTION
Hello!

This PR adds a "-d" option to the astisub command, which sets a bool in the option struct passed to Open().
On reading a STL file, outputs to stdout:
* some values of the GSI block
* subtitle lines with their number, start time, end time, vertical position and number of line (and exclamation marks if something odd in timestamps)
* the total number of errors encountered

It is designed for the interactive human user, no concern has been given to automatic parsing of this output.

```
STL:GSIBlock
STL:  DisplayStandardCode:0x31
STL:  TotalNumberOfTTIBlocks:959
STL:  TotalNumberOfSubtitleGroups:1
STL:  TotalNumberOfSubtitles:959
STL:
STL: #0000   00000.080 - 00002.000   vp=22	lines=1 [*Thème musical de l'émission]
STL: #0001   00002.200 - 00004.800   vp=22	lines=1 [...]
STL: #0002   00005.000 - 00008.760   vp=20	lines=2 [-Mais oui ! Mais oui, les petits potes sont là,]
[...]
STL: #0378 ! 00990.560 - 00988.640 ! vp=16	lines=1 [avant celui pour le public belge.]
[...]
STL: #0958   02614.560 - 02618.400   vp=20	lines=2 [Sous-titrage ST' 501]
STL: 1 error(s)
```

Maybe it would be a better idea to do the lines output at the end of subtitles.go:Open, so it would be common to all kinds of subtitles and not clutter stl.go.

An unoprotected global struct keeps the debug state: debug is not really meant to be enabled when using astisub as a lib.

Not sure if it's worth being incorporated in astisub, but I keep going back to that debug output when problems are signaled in our subs ;)
