### PR TITLE
webvtt: Handle X-TIMESTAMP-MAP header

### DIFF
--- a/webvtt_internal_test.go
+++ b/webvtt_internal_test.go
@@ -1,7 +1,9 @@
 package astisub
 
 import (
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -34,4 +36,55 @@ func TestParseTextWebVTT(t *testing.T) {
 		assert.Equal(t, 1, len(s.Items))
 		assert.Equal(t, "Incorrect end tag", s.Items[0].Text)
 	})
+}
+
+func TestTimestampMap(t *testing.T) {
+	for i, c := range []struct {
+		line           string
+		expectedOffset time.Duration
+		expectError    bool
+	}{
+		{
+			line:           "X-TIMESTAMP-MAP=MPEGTS:180000, LOCAL:00:00:00.000",
+			expectedOffset: 2 * time.Second,
+		},
+		{
+			line:           "X-TIMESTAMP-MAP=MPEGTS:180000, LOCAL:00:00:00.500",
+			expectedOffset: 1500 * time.Millisecond,
+		},
+		{
+			line:           "X-TIMESTAMP-MAP=LOCAL:00:00:00.000,MPEGTS:135000",
+			expectedOffset: 1500 * time.Millisecond,
+		},
+		{
+			line:           "X-TIMESTAMP-MAP=LOCAL:00:00:00.000,MPEGTS:324090000",
+			expectedOffset: time.Hour + time.Second,
+		},
+		{
+			line:        "X-TIMESTAMP-MAP=MPEGTS:foo, LOCAL:00:00:00.000",
+			expectError: true,
+		},
+		{
+			line:        "X-TIMESTAMP-MAP=MPEGTS:180000,LOCAL:bar",
+			expectError: true,
+		},
+		{
+			line:        "X-TIMESTAMP-MAP=MPEGTS:180000,LOCAL",
+			expectError: true,
+		},
+		{
+			line:        "X-TIMESTAMP-MAP=MPEGTS,LOCAL:00:00:00.000",
+			expectError: true,
+		},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			offset, err := parseTimestampMapWebVTT(c.line)
+			assert.Equal(t, c.expectedOffset, offset)
+			if c.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }

--- a/webvtt_test.go
+++ b/webvtt_test.go
@@ -100,3 +100,33 @@ NOTE this a example with voicename
 <v Bob>Incorrect tag?
 `, b.String())
 }
+
+func TestWebVTTWithTimestampMap(t *testing.T) {
+	testData := `WEBVTT
+	X-TIMESTAMP-MAP=MPEGTS:180000, LOCAL:00:00:00.000
+
+	00:00.933 --> 00:02.366
+	♪ ♪
+
+	00:02.400 --> 00:03.633
+	Evening.`
+
+	s, err := astisub.ReadFromWebVTT(strings.NewReader(testData))
+	assert.NoError(t, err)
+
+	assert.Len(t, s.Items, 2)
+
+	b := &bytes.Buffer{}
+	err = s.WriteToWebVTT(b)
+	assert.NoError(t, err)
+	assert.Equal(t, `WEBVTT
+
+1
+00:00:02.933 --> 00:00:04.366
+♪ ♪
+
+2
+00:00:04.400 --> 00:00:05.633
+Evening.
+`, b.String())
+}


### PR DESCRIPTION
When specified, X-TIMESTAMP-MAP should be used to compute an offset for
each subtitle record in the file.