### PR TITLE
Propagate STL vertical position to WebVTT

### DIFF
--- a/subtitles.go
+++ b/subtitles.go
@@ -261,6 +261,9 @@ func (sa *StyleAttributes) propagateSTLAttributes() {
 			sa.WebVTTAlign = "left"
 		}
 	}
+	if sa.STLPosition != nil && sa.STLPosition.MaxRows > 0 {
+		sa.WebVTTLine = fmt.Sprintf("%d%%", int(sa.STLPosition.VerticalPosition*100/sa.STLPosition.MaxRows))
+	}
 }
 
 func (sa *StyleAttributes) propagateTeletextAttributes() {

--- a/subtitles.go
+++ b/subtitles.go
@@ -262,7 +262,7 @@ func (sa *StyleAttributes) propagateSTLAttributes() {
 		}
 	}
 	if sa.STLPosition != nil && sa.STLPosition.MaxRows > 0 {
-		sa.WebVTTLine = fmt.Sprintf("%d%%", int(sa.STLPosition.VerticalPosition*100/sa.STLPosition.MaxRows))
+		sa.WebVTTLine = fmt.Sprintf("%d%%", sa.STLPosition.VerticalPosition*100/sa.STLPosition.MaxRows)
 	}
 }
 


### PR DESCRIPTION
It should work with both teletext (Max Number of Rows = 23) and in-vision (MNR=0..99) subtitles, but only tested on teletext subtitles (no-op if MNR == 0 to avoid zero division).
It propagates the STL VP to the WebVTT line attribute, as percentage, by diving the row number by the max number of rows.
For example, if VP = 22 in a teletext TTI, then percentage = int(22*100/23) = 95, thus it will output "line:95%" in the VTT file.
