### PR TITLE
fix vertical position conversion from stl teletext to webvtt

### DIFF
--- a/subtitles.go
+++ b/subtitles.go
@@ -265,7 +265,10 @@ func (sa *StyleAttributes) propagateSTLAttributes() {
 	if sa.STLPosition != nil && sa.STLPosition.MaxRows > 0 {
 		// in-vision vertical position ranges from 0 to maxrows (maxrows <= 99)
 		sa.WebVTTLine = fmt.Sprintf("%d%%", sa.STLPosition.VerticalPosition*100/sa.STLPosition.MaxRows)
-		// teletext vertical position ranges from 1 to 23
+		// teletext vertical position ranges from 1 to 23; as webvtt line percentage starts
+		// from the top at 0%, substract 1 to the stl position to get a better conversion.
+		// Especially apparent on Shaka player, where a single line at vp 22 would be half
+		// out of bounds at 95% (22*100/23), and fine at 91% (21*100/23)
 		if sa.STLPosition.MaxRows == 23 && sa.STLPosition.VerticalPosition > 0 {
 			sa.WebVTTLine = fmt.Sprintf("%d%%", (sa.STLPosition.VerticalPosition-1)*100/sa.STLPosition.MaxRows)
 		}

--- a/subtitles.go
+++ b/subtitles.go
@@ -261,8 +261,14 @@ func (sa *StyleAttributes) propagateSTLAttributes() {
 			sa.WebVTTAlign = "left"
 		}
 	}
+	// converts STL vertical position (row number) to WebVTT line percentage
 	if sa.STLPosition != nil && sa.STLPosition.MaxRows > 0 {
+		// in-vision vertical position ranges from 0 to maxrows (maxrows <= 99)
 		sa.WebVTTLine = fmt.Sprintf("%d%%", sa.STLPosition.VerticalPosition*100/sa.STLPosition.MaxRows)
+		// teletext vertical position ranges from 1 to 23
+		if sa.STLPosition.MaxRows == 23 && sa.STLPosition.VerticalPosition > 0 {
+			sa.WebVTTLine = fmt.Sprintf("%d%%", (sa.STLPosition.VerticalPosition-1)*100/sa.STLPosition.MaxRows)
+		}
 	}
 }
 


### PR DESCRIPTION
Would you believe I made an off-by-one error when converting the STL vertical position of a teletext subtitle (going from 1 to 23) to a WebVTT line percentage (starting from 0% -- a line at the bottom should be at about 91%) ?
It appeared correctly in VLC and iOS native player, but in some other players (Shaka ...), the vertical positioning was visibly too low.
This PR fixes the problem by subtracting 1 to the row number when converting a teletext subtitle.
