### PR TITLE
Support parsing srt without sequence numbers.

### DIFF
--- a/srt.go
+++ b/srt.go
@@ -51,15 +51,15 @@ func ReadFromSRT(i io.Reader) (o *Subtitles, err error) {
 
 		// Line contains time boundaries
 		if strings.Contains(line, srtTimeBoundariesSeparator) {
-			// Return the wrong number of rows
-			if len(s.Lines) == 0 {
-				err = fmt.Errorf("astisub: line %d: no lines", lineNum)
-				return
+			// Remove last item of previous subtitle since it should be the index.
+			// If the last line is empty then the item is missing an index.
+			var index string
+			if len(s.Lines) != 0 {
+				index := s.Lines[len(s.Lines)-1].String()
+				if index != "" {
+					s.Lines = s.Lines[:len(s.Lines)-1]
+				}
 			}
-
-			// Remove last item of previous subtitle since it's the index
-			index := s.Lines[len(s.Lines)-1]
-			s.Lines = s.Lines[:len(s.Lines)-1]
 
 			// Remove trailing empty lines
 			if len(s.Lines) > 0 {
@@ -84,7 +84,9 @@ func ReadFromSRT(i io.Reader) (o *Subtitles, err error) {
 			s = &Item{}
 
 			// Fetch Index
-			s.Index, _ = strconv.Atoi(index.String())
+			if index != "" {
+				s.Index, _ = strconv.Atoi(index)
+			}
 
 			// Extract time boundaries
 			s1 := strings.Split(line, srtTimeBoundariesSeparator)

--- a/srt_test.go
+++ b/srt_test.go
@@ -27,3 +27,22 @@ func TestSRT(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, string(c), w.String())
 }
+
+func TestSRTMissingSequence(t *testing.T) {
+	// Open
+	s, err := astisub.OpenFile("./testdata/missing-sequence-in.srt")
+	assert.NoError(t, err)
+	assertSubtitleItems(t, s)
+
+	// No subtitles to write
+	w := &bytes.Buffer{}
+	err = astisub.Subtitles{}.WriteToSRT(w)
+	assert.EqualError(t, err, astisub.ErrNoSubtitlesToWrite.Error())
+
+	// Write
+	c, err := ioutil.ReadFile("./testdata/missing-sequence-out.srt")
+	assert.NoError(t, err)
+	err = s.WriteToSRT(w)
+	assert.NoError(t, err)
+	assert.Equal(t, string(c), w.String())
+}

--- a/testdata/missing-sequence-in.srt
+++ b/testdata/missing-sequence-in.srt
@@ -1,0 +1,20 @@
+00:01:39 --> 00:01:41,04
+(deep rumbling)
+
+00:02:04,08 --> 00:02:07,12 X1:40 X2:600 Y1:20 Y2:50
+MAN:
+How did we end up here?
+
+00:02:12.16 --> 00:02:15.20
+This place is horrible.
+
+00:02:20.24 --> 00:02:22.28
+Smells like balls.
+
+00:02:28,32 --> 00:02:31,36
+We don't belong
+in this shithole.
+
+00:02:31,40 --> 00:02:33,44
+(computer playing
+electronic melody)

--- a/testdata/missing-sequence-out.srt
+++ b/testdata/missing-sequence-out.srt
@@ -1,0 +1,26 @@
+﻿1
+00:01:39,000 --> 00:01:41,040
+(deep rumbling)
+
+2
+00:02:04,080 --> 00:02:07,120
+MAN:
+How did we end up here?
+
+3
+00:02:12,160 --> 00:02:15,200
+This place is horrible.
+
+4
+00:02:20,240 --> 00:02:22,280
+Smells like balls.
+
+5
+00:02:28,320 --> 00:02:31,360
+We don't belong
+in this shithole.
+
+6
+00:02:31,400 --> 00:02:33,440
+(computer playing
+electronic melody)


### PR DESCRIPTION
There are many srt in the wild that are missing sequence numbers. It's easy to detect by looking for an empty line vs index/sequence in the line before the time. In my analysis of many srt I have not seen ones missing the empty line, but it's feasible that these also exist. This shouldn't affect parsing otherwise, however, and in my experience the missing sequence number is common enough that it's useful to handle.