### PR TITLE
Simple support for WebVTT style

### DIFF
--- a/subtitles.go
+++ b/subtitles.go
@@ -243,10 +243,10 @@ type StyleAttributes struct {
 	WebVTTRegionAnchor   string
 	WebVTTScroll         string
 	WebVTTSize           string
+	WebVTTStyles         []string
 	WebVTTVertical       string
 	WebVTTViewportAnchor string
 	WebVTTWidth          string
-	WebVTTCSS            string
 }
 
 func (sa *StyleAttributes) propagateSSAAttributes() {}

--- a/subtitles.go
+++ b/subtitles.go
@@ -246,6 +246,7 @@ type StyleAttributes struct {
 	WebVTTVertical       string
 	WebVTTViewportAnchor string
 	WebVTTWidth          string
+	WebVTTCSS            string
 }
 
 func (sa *StyleAttributes) propagateSSAAttributes() {}

--- a/testdata/example-in.vtt
+++ b/testdata/example-in.vtt
@@ -7,6 +7,20 @@ STYLE
 ::cue(b) {
   color: peachpuff;
 }
+::cue(c) {
+  color: white;
+}
+
+STYLE
+::cue(a) {
+  color: red;
+}
+::cue(d) {
+  color: red;
+
+  background-image: linear-gradient(to bottom, dimgray, lightgray);
+}
+
 
 Region: id=fred width=40% lines=3 regionanchor=0%,100% viewportanchor=10%,90% scroll=up
 Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% scroll=up

--- a/testdata/example-out.vtt
+++ b/testdata/example-out.vtt
@@ -1,5 +1,10 @@
 WEBVTT
 
+STYLE
+::cue(b) {
+color: peachpuff;
+}
+
 Region: id=bill lines=3 regionanchor=100%,100% scroll=up viewportanchor=90%,90% width=40%
 Region: id=fred lines=3 regionanchor=0%,100% scroll=up viewportanchor=10%,90% width=40%
 

--- a/testdata/example-out.vtt
+++ b/testdata/example-out.vtt
@@ -4,6 +4,16 @@ STYLE
 ::cue(b) {
 color: peachpuff;
 }
+::cue(c) {
+color: white;
+}
+::cue(a) {
+color: red;
+}
+::cue(d) {
+color: red;
+background-image: linear-gradient(to bottom, dimgray, lightgray);
+}
 
 Region: id=bill lines=3 regionanchor=100%,100% scroll=up viewportanchor=90%,90% width=40%
 Region: id=fred lines=3 regionanchor=0%,100% scroll=up viewportanchor=10%,90% width=40%


### PR DESCRIPTION
Hi all,

Now, we will lose all of WebVTT style after reading it, process somethings and write to WebVTT format again. This PR provide a simple WebVTT style handling, since CSS support many properties, I will not parsing them all, we will just blindly store all the things in `STYLE` and rewrite them when writing WebVTT again. We will love some spaces and new lines, but it's not a big duel. Besides, when merging `subtitles2` into `subtitles1`, if there are duplicated CSS selectors, only the CSS style of `subtitles1` will be kept.