### PR TITLE
Preserve WebVTT tags in subtitle lines

### DIFF
--- a/subtitles.go
+++ b/subtitles.go
@@ -236,7 +236,6 @@ type StyleAttributes struct {
 	TTMLWritingMode      *string
 	TTMLZIndex           *int
 	WebVTTAlign          string
-	WebVTTItalics        bool
 	WebVTTLine           string
 	WebVTTLines          int
 	WebVTTPosition       string
@@ -244,9 +243,40 @@ type StyleAttributes struct {
 	WebVTTScroll         string
 	WebVTTSize           string
 	WebVTTStyles         []string
+	WebVTTTags           []WebVTTTag
 	WebVTTVertical       string
 	WebVTTViewportAnchor string
 	WebVTTWidth          string
+}
+
+type WebVTTTag struct {
+	Name       string
+	Annotation string
+	Classes    []string
+}
+
+func (t WebVTTTag) startTag() string {
+	if t.Name == "" {
+		return ""
+	}
+
+	s := t.Name
+	if len(t.Classes) > 0 {
+		s += "." + strings.Join(t.Classes, ".")
+	}
+
+	if t.Annotation != "" {
+		s += " " + t.Annotation
+	}
+
+	return "<" + s + ">"
+}
+
+func (t WebVTTTag) endTag() string {
+	if t.Name == "" {
+		return ""
+	}
+	return "</" + t.Name + ">"
 }
 
 func (sa *StyleAttributes) propagateSSAAttributes() {}

--- a/webvtt_internal_test.go
+++ b/webvtt_internal_test.go
@@ -96,39 +96,39 @@ func TestCueVoiceSpanRegex(t *testing.T) {
 	}{
 		{
 			give: `<v 中文> this is the content</v>`,
-			want: ` 中文`,
+			want: `中文`,
 		},
 		{
 			give: `<v 中文> this is the content`,
-			want: ` 中文`,
+			want: `中文`,
 		},
 		{
 			give: `<v.abc 中文> this is the content</v>`,
-			want: ` 中文`,
+			want: `中文`,
 		},
 		{
 			give: `<v.jp 言語の> this is the content`,
-			want: ` 言語の`,
+			want: `言語の`,
 		},
 		{
 			give: `<v.ko 언어> this is the content`,
-			want: ` 언어`,
+			want: `언어`,
 		},
 		{
 			give: `<v foo bar> this is the content`,
-			want: ` foo bar`,
+			want: `foo bar`,
 		},
 		{
 			give: `<v هذا عربي> this is the content`,
-			want: ` هذا عربي`,
+			want: `هذا عربي`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.want, func(t *testing.T) {
-			results := webVTTRegexpStartTag.FindStringSubmatch(tt.give)
-			assert.True(t, len(results) == 4)
-			assert.Equal(t, tt.want, results[3])
+			results := webVTTRegexpTag.FindStringSubmatch(tt.give)
+			assert.True(t, len(results) == 5)
+			assert.Equal(t, tt.want, results[4])
 		})
 	}
 }

--- a/webvtt_test.go
+++ b/webvtt_test.go
@@ -162,3 +162,53 @@ Sentence with an &amp; in the middle
 Sentence with an &lt; in the middle
 `, b.String())
 }
+
+func TestWebVTTTags(t *testing.T) {
+	testData := `WEBVTT
+
+	00:01:00.000 --> 00:02:00.000
+	<u><i>Italic with underline text</i></u> some extra
+
+	00:02:00.000 --> 00:03:00.000
+	<lang en>English here</lang> <c.yellow.bg_blue>Yellow text on blue background</c>
+
+	00:03:00.000 --> 00:04:00.000
+	<v Joe><c.red><i>Joe's words are red in italic</i></c>
+
+	00:04:00.000 --> 00:05:00.000
+	<customed_tag.class1.class2>Text here</customed_tag>
+
+	00:05:00.000 --> 00:06:00.000
+	<v Joe>Joe says something</v> <v Bob>Bob says something</v>`
+
+	s, err := astisub.ReadFromWebVTT(strings.NewReader(testData))
+	require.NoError(t, err)
+
+	require.Len(t, s.Items, 5)
+
+	b := &bytes.Buffer{}
+	err = s.WriteToWebVTT(b)
+	require.NoError(t, err)
+	require.Equal(t, `WEBVTT
+
+1
+00:01:00.000 --> 00:02:00.000
+<u><i>Italic with underline text</i></u> some extra
+
+2
+00:02:00.000 --> 00:03:00.000
+<lang en>English here</lang> <c.yellow.bg_blue>Yellow text on blue background</c>
+
+3
+00:03:00.000 --> 00:04:00.000
+<v Joe><c.red><i>Joe's words are red in italic</i></c>
+
+4
+00:04:00.000 --> 00:05:00.000
+<customed_tag.class1.class2>Text here</customed_tag>
+
+5
+00:05:00.000 --> 00:06:00.000
+<v Joe>Joe says something Bob says something
+`, b.String())
+}


### PR DESCRIPTION
Hi all,

WebVTT STYLE block is CSS and it allow to write custom CSS class or tag in xml to applied to the lines of WebVTT, also, some default tag like tag i (italic), b (bold), u (underline), etc are supported too, for example:
```
WEBVTT

00:01:00.000 --> 00:02:00.000
<u><i>Italic with underline text</i></u> some extra

00:02:00.000 --> 00:03:00.000
<lang en>English here</lang> <c.yellow.bg_blue>Yellow text on blue background</c>

00:03:00.000 --> 00:04:00.000
<v Joe><c.red><i>Joe's words are red in italic</i></c>

00:04:00.000 --> 00:05:00.000
<customed_tag.class1.class2>Text here</customed_tag>
```
So, I add these change to preserve the tags in WebVTT files. This will be convenient if someday, we decide to convert styling from WebVTT to TTML or another format.

According to WebVTT format at: https://www.w3.org/TR/webvtt1/