### PR TITLE
[ttml] Rename ttml decoder to token reader and correct test data

### DIFF
--- a/testdata/example-in-breaklines.ttml
+++ b/testdata/example-in-breaklines.ttml
@@ -4,20 +4,16 @@
   <body>
     <div>
       <p xml:id="1" begin="00:00:00.000" end="00:00:01.000">
-        <span>First line<br/>
-Second line</span>
+        <span>First line<br/>Second line</span>
       </p>
       <p xml:id="2" begin="00:00:01.000" end="00:00:02.000">
         <span>Third line<br></br>Fourth line</span>
       </p>
       <p xml:id="3" begin="00:00:02.000" end="00:00:03.000">
-                Fifth line
-        <br/>
-                Sixth <span>middle</span> line
+        Fifth line<br/>Sixth <span>middle</span> line
       </p>
       <p xml:id="4" begin="00:00:03.000" end="00:00:04.000">
-        Seventh line 
-        <br></br>Eighth <span>middle</span> line
+        Seventh line <br></br>Eighth <span>middle</span> line
       </p>
     </div>
   </body>

--- a/testdata/example-out-breaklines.ttml
+++ b/testdata/example-out-breaklines.ttml
@@ -11,7 +11,9 @@
                 <span>Second line</span>
             </p>
             <p begin="00:00:01.000" end="00:00:02.000">
-                <span>Third lineFourth line</span>
+                <span>Third line</span>
+                <br></br>
+                <span>Fourth line</span>
             </p>
             <p begin="00:00:02.000" end="00:00:03.000">
                 <span>Fifth line</span>

--- a/ttml.go
+++ b/ttml.go
@@ -197,22 +197,22 @@ func (i *TTMLInItems) UnmarshalXML(d *xml.Decoder, start xml.StartElement) (err 
 	return nil
 }
 
-type ttmlXmlDecoder struct {
-	xml.Decoder
-	holdingToken xml.Token
+type ttmlXmlTokenReader struct {
+	xmlTokenReader xml.TokenReader
+	holdingToken   xml.Token
 }
 
 // Token implements the TokenReader interface, when it meets the "br" tag, it will hold the token and return a newline
 // instead. This is to work around the fact that the go xml unmarshaler will ignore the "br" tag if it's within a
 // character data field.
-func (r *ttmlXmlDecoder) Token() (xml.Token, error) {
+func (r *ttmlXmlTokenReader) Token() (xml.Token, error) {
 	if r.holdingToken != nil {
 		returnToken := r.holdingToken
 		r.holdingToken = nil
 		return returnToken, nil
 	}
 
-	t, err := r.Decoder.Token()
+	t, err := r.xmlTokenReader.Token()
 	if err != nil {
 		return nil, err
 	}
@@ -225,8 +225,13 @@ func (r *ttmlXmlDecoder) Token() (xml.Token, error) {
 	return t, nil
 }
 
-func newTTMLXmlDecoder(ts TTMLInSubtitle) *ttmlXmlDecoder {
-	return &ttmlXmlDecoder{Decoder: *xml.NewDecoder(strings.NewReader("<p>" + ts.Items + "</p>")), holdingToken: nil}
+func newTTMLXmlDecoder(ts TTMLInSubtitle) *xml.Decoder {
+	return xml.NewTokenDecoder(
+		&ttmlXmlTokenReader{
+			xmlTokenReader: xml.NewDecoder(strings.NewReader("<p>" + ts.Items + "</p>")),
+			holdingToken:   nil,
+		},
+	)
 }
 
 // TTMLInItem represents an input TTML item


### PR DESCRIPTION
Hi,

My apologize, after changing the token reader to decoder, the code does not work as expected. Or we can say that the polymorphism of Golang is not like what we have in C++, Java, etc, there is no parent and child object so I miss-understood that it will work as expected. I need to wash my brain after years of coding in traditional polymophism. And, with some coincidence, I let vscode extension to automatically edit the input ttml, that extension added some more newlines character and make the output is pretty normal to me and I am blind. My carelessness :bow: 