### PR TITLE
fix: Add support for X-TIMESTAMP-MAP r/w persistence

### DIFF
--- a/subtitles.go
+++ b/subtitles.go
@@ -392,6 +392,24 @@ type Metadata struct {
 	STLTranslatorName                                   string
 	Title                                               string
 	TTMLCopyright                                       string
+	WebVTTXTimestampMap                                 *TimestampMap
+}
+
+// TimestampMap is a structure for storing timestamps for WEBVTT's
+// X-TIMESTAMP-MAP feature commonly used for syncing cue times with
+// MPEG-TS streams.
+type TimestampMap struct {
+	LocalTimestamp        time.Duration
+	PresentationTimestamp int64
+}
+
+// Offset calculates and returns the time offset described by the
+// timestamp map.
+func (t *TimestampMap) Offset() time.Duration {
+	if t == nil {
+		return 0
+	}
+	return time.Duration(t.PresentationTimestamp)*time.Second/90000 - t.LocalTimestamp
 }
 
 // Region represents a subtitle's region

--- a/subtitles.go
+++ b/subtitles.go
@@ -392,24 +392,7 @@ type Metadata struct {
 	STLTranslatorName                                   string
 	Title                                               string
 	TTMLCopyright                                       string
-	WebVTTXTimestampMap                                 *TimestampMap
-}
-
-// TimestampMap is a structure for storing timestamps for WEBVTT's
-// X-TIMESTAMP-MAP feature commonly used for syncing cue times with
-// MPEG-TS streams.
-type TimestampMap struct {
-	LocalTimestamp        time.Duration
-	PresentationTimestamp int64
-}
-
-// Offset calculates and returns the time offset described by the
-// timestamp map.
-func (t *TimestampMap) Offset() time.Duration {
-	if t == nil {
-		return 0
-	}
-	return time.Duration(t.PresentationTimestamp)*time.Second/90000 - t.LocalTimestamp
+	WebVTTTimestampMap                                  *WebVTTTimestampMap
 }
 
 // Region represents a subtitle's region

--- a/webvtt.go
+++ b/webvtt.go
@@ -66,7 +66,7 @@ func (t *WebVTTTimestampMap) Offset() time.Duration {
 func (t *WebVTTTimestampMap) String() string {
 	mpegts := fmt.Sprintf("MPEGTS:%d", t.MpegTS)
 	local := fmt.Sprintf("LOCAL:%s", formatDurationWebVTT(t.Local))
-	return fmt.Sprintf("%s=%s,%s", webvttTimestampMapHeader, mpegts, local)
+	return fmt.Sprintf("%s=%s,%s", webvttTimestampMapHeader, local, mpegts)
 }
 
 // https://tools.ietf.org/html/rfc8216#section-3.5

--- a/webvtt_internal_test.go
+++ b/webvtt_internal_test.go
@@ -74,11 +74,11 @@ func TestTimestampMap(t *testing.T) {
 		expectError    bool
 	}{
 		{
-			line:           "X-TIMESTAMP-MAP=MPEGTS:180000, LOCAL:00:00:00.000",
+			line:           "X-TIMESTAMP-MAP=LOCAL:00:00:00.000,MPEGTS:180000",
 			expectedOffset: 2 * time.Second,
 		},
 		{
-			line:           "X-TIMESTAMP-MAP=MPEGTS:180000, LOCAL:00:00:00.500",
+			line:           "X-TIMESTAMP-MAP=LOCAL:00:00:00.500,MPEGTS:180000",
 			expectedOffset: 1500 * time.Millisecond,
 		},
 		{
@@ -113,6 +113,7 @@ func TestTimestampMap(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+				assert.Equal(t, c.line, timestampMap.String())
 			}
 		})
 	}

--- a/webvtt_internal_test.go
+++ b/webvtt_internal_test.go
@@ -107,9 +107,8 @@ func TestTimestampMap(t *testing.T) {
 		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			timestampMap, err := parseTimestampMapWebVTT(c.line)
-			offset := timestampMap.Offset()
-			assert.Equal(t, c.expectedOffset, offset)
+			timestampMap, err := parseWebVTTTimestampMap(c.line)
+			assert.Equal(t, c.expectedOffset, timestampMap.Offset())
 			if c.expectError {
 				assert.Error(t, err)
 			} else {

--- a/webvtt_internal_test.go
+++ b/webvtt_internal_test.go
@@ -107,7 +107,8 @@ func TestTimestampMap(t *testing.T) {
 		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			offset, err := parseTimestampMapWebVTT(c.line)
+			timestampMap, err := parseTimestampMapWebVTT(c.line)
+			offset := timestampMap.Offset()
 			assert.Equal(t, c.expectedOffset, offset)
 			if c.expectError {
 				assert.Error(t, err)

--- a/webvtt_test.go
+++ b/webvtt_test.go
@@ -121,6 +121,25 @@ func TestWebVTTWithTimestampMap(t *testing.T) {
 	err = s.WriteToWebVTT(b)
 	assert.NoError(t, err)
 	assert.Equal(t, `WEBVTT
+X-TIMESTAMP-MAP=MPEGTS:180000,LOCAL:00:00:00.000
+
+1
+00:00:00.933 --> 00:00:02.366
+♪ ♪
+
+2
+00:00:02.400 --> 00:00:03.633
+Evening.
+`, b.String())
+
+	// Apply MPEG-TS time correction
+	s.Add(s.Metadata.WebVTTXTimestampMap.Offset())
+	s.Metadata.WebVTTXTimestampMap = nil
+
+	b = &bytes.Buffer{}
+	err = s.WriteToWebVTT(b)
+	assert.NoError(t, err)
+	assert.Equal(t, `WEBVTT
 
 1
 00:00:02.933 --> 00:00:04.366

--- a/webvtt_test.go
+++ b/webvtt_test.go
@@ -133,8 +133,8 @@ Evening.
 `, b.String())
 
 	// Apply MPEG-TS time correction
-	s.Add(s.Metadata.WebVTTXTimestampMap.Offset())
-	s.Metadata.WebVTTXTimestampMap = nil
+	s.Add(s.Metadata.WebVTTTimestampMap.Offset())
+	s.Metadata.WebVTTTimestampMap = nil
 
 	b = &bytes.Buffer{}
 	err = s.WriteToWebVTT(b)

--- a/webvtt_test.go
+++ b/webvtt_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/asticode/go-astisub"
 	"github.com/stretchr/testify/assert"
@@ -117,6 +118,12 @@ func TestWebVTTWithTimestampMap(t *testing.T) {
 
 	assert.Len(t, s.Items, 2)
 
+	assert.Equal(t, s.Items[0].StartAt.Milliseconds(), int64(933))
+	assert.Equal(t, s.Items[0].EndAt.Milliseconds(), int64(2366))
+	assert.Equal(t, s.Items[1].StartAt.Milliseconds(), int64(2400))
+	assert.Equal(t, s.Items[1].EndAt.Milliseconds(), int64(3633))
+	assert.Equal(t, s.Metadata.WebVTTTimestampMap.Offset(), time.Duration(time.Second*2))
+
 	b := &bytes.Buffer{}
 	err = s.WriteToWebVTT(b)
 	assert.NoError(t, err)
@@ -129,24 +136,6 @@ X-TIMESTAMP-MAP=LOCAL:00:00:00.000,MPEGTS:180000
 
 2
 00:00:02.400 --> 00:00:03.633
-Evening.
-`, b.String())
-
-	// Apply MPEG-TS time correction
-	s.Add(s.Metadata.WebVTTTimestampMap.Offset())
-	s.Metadata.WebVTTTimestampMap = nil
-
-	b = &bytes.Buffer{}
-	err = s.WriteToWebVTT(b)
-	assert.NoError(t, err)
-	assert.Equal(t, `WEBVTT
-
-1
-00:00:02.933 --> 00:00:04.366
-♪ ♪
-
-2
-00:00:04.400 --> 00:00:05.633
 Evening.
 `, b.String())
 }

--- a/webvtt_test.go
+++ b/webvtt_test.go
@@ -121,7 +121,7 @@ func TestWebVTTWithTimestampMap(t *testing.T) {
 	err = s.WriteToWebVTT(b)
 	assert.NoError(t, err)
 	assert.Equal(t, `WEBVTT
-X-TIMESTAMP-MAP=MPEGTS:180000,LOCAL:00:00:00.000
+X-TIMESTAMP-MAP=LOCAL:00:00:00.000,MPEGTS:180000
 
 1
 00:00:00.933 --> 00:00:02.366


### PR DESCRIPTION
As I mentioned in [this issue here](https://github.com/asticode/go-astisub/issues/111), I'd like to be able to specify an `X-TIMESTAMP-MAP` based on some external factors in my application which uses astisub. However, as part of this, I think that the WebVTT reader automatically applying the time offset defined therein will cause duplicate applications of the time offset in the case where a WebVTT with an `X-TIMESTAMP-MAP` is read, manipulated, then also written back out. 

So this PR adds a struct for storing the parsed `X-TIMESTAMP-MAP` data on the `Subtitles`' Metadata field, that way it can be manually applied to the subtitles if necessary, or left as is and written back to WebVTT files so that some upstream client can apply the time correction. Likewise, this also allows manually configuring a `X-TIMESTAMP-MAP` to be written to a WebVTT file when it previously did not exist there, the use-case I originally needed to solve for. 