### PR TITLE
Enforce UTF-8 encoding for input bytes

### DIFF
--- a/srt.go
+++ b/srt.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // Constants
@@ -42,6 +43,10 @@ func ReadFromSRT(i io.Reader) (o *Subtitles, err error) {
 	for scanner.Scan() {
 		// Fetch line
 		line = strings.TrimSpace(scanner.Text())
+		if !utf8.ValidString(line) {
+			err = fmt.Errorf("astisub: bytes are not valid utf-8")
+			return
+		}
 		lineNum++
 
 		// Remove BOM header

--- a/webvtt.go
+++ b/webvtt.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"golang.org/x/net/html"
 )
@@ -127,6 +128,10 @@ func ReadFromWebVTT(i io.Reader) (o *Subtitles, err error) {
 	for scanner.Scan() {
 		lineNum++
 		line = scanner.Text()
+		if !utf8.ValidString(line) {
+			err = fmt.Errorf("astisub: bytes are not valid utf-8")
+			return
+		}
 		line = strings.TrimPrefix(line, string(BytesBOM))
 		if fs := strings.Fields(line); len(fs) > 0 && fs[0] == "WEBVTT" {
 			break


### PR DESCRIPTION
As discussed in #114, it would be better if we tried not to read bytes in other encoding if possible, as the parsers will become confused since they are generally using strings from a go source file (UTF-8) to compare against the input bytes which may or may not be UTF-8. 