### PR TITLE
stl: improve error messages

### DIFF
--- a/stl.go
+++ b/stl.go
@@ -584,28 +584,28 @@ func parseDurationSTL(i string, framerate int) (d time.Duration, err error) {
 	// Parse hours
 	var hours, hoursString = 0, i[0:2]
 	if hours, err = strconv.Atoi(hoursString); err != nil {
-		err = fmt.Errorf("hours: atoi of %s failed: %w", hoursString, err)
+		err = fmt.Errorf("astisub: hours atoi of %s failed: %w", hoursString, err)
 		return
 	}
 
 	// Parse minutes
 	var minutes, minutesString = 0, i[2:4]
 	if minutes, err = strconv.Atoi(minutesString); err != nil {
-		err = fmt.Errorf("minutes: atoi of %s failed: %w", minutesString, err)
+		err = fmt.Errorf("astisub: minutes atoi of %s failed: %w", minutesString, err)
 		return
 	}
 
 	// Parse seconds
 	var seconds, secondsString = 0, i[4:6]
 	if seconds, err = strconv.Atoi(secondsString); err != nil {
-		err = fmt.Errorf("seconds: atoi of %s failed: %w", secondsString, err)
+		err = fmt.Errorf("astisub: seconds atoi of %s failed: %w", secondsString, err)
 		return
 	}
 
 	// Parse frames
 	var frames, framesString = 0, i[6:8]
 	if frames, err = strconv.Atoi(framesString); err != nil {
-		err = fmt.Errorf("frames: atoi of %s failed: %w", framesString, err)
+		err = fmt.Errorf("astisub: frames atoi of %s failed: %w", framesString, err)
 		return
 	}
 


### PR DESCRIPTION
Encountered the following error message on a bad STL file:
`astisub: building gsi block failed: astisub: atoi of  failed: strconv.Atoi: parsing "\x01": invalid syntax`

Decided to replace the second occurence of "astisub" with the name of the target variable, in every place with int or date parsing, so this PR will output:
`astisub: building gsi block failed: totalNumberOfDisks: atoi of  failed: strconv.Atoi: parsing "\x01": invalid syntax`
which makes it easier to pinpoint the bad location in the STL file.

(one could also wonder if it would be worth it to replace the %s of "atoi of %s failed" with a %q, in case of a non-printable string like in this example ...)

Bonus, line 835, removed the "astisub: " prefix which is redundant with the message line 206 in ReadFromSTL(). 
