### PR TITLE
Add support for colon delimited milliseconds for srt

### DIFF
--- a/srt.go
+++ b/srt.go
@@ -23,7 +23,7 @@ var (
 
 // parseDurationSRT parses an .srt duration
 func parseDurationSRT(i string) (d time.Duration, err error) {
-	for _, s := range []string{",", "."} {
+	for _, s := range []string{",", ".", ":"} {
 		if d, err = parseDuration(i, s, 3); err == nil {
 			return
 		}

--- a/srt_test.go
+++ b/srt_test.go
@@ -145,13 +145,21 @@ func TestSRTParseDuration(t *testing.T) {
 	testData := `
 	1
 	00:00:01.876-->00:0:03.390
-	Duration without enclosing space`
+	Duration without enclosing space
+	
+	2
+	00:00:04:609-->00:0:05:985
+	Duration without colon milliseconds`
 
 	s, err := astisub.ReadFromSRT(strings.NewReader(testData))
 	require.NoError(t, err)
 
-	require.Len(t, s.Items, 1)
+	require.Len(t, s.Items, 2)
 	assert.Equal(t, 1*time.Second+876*time.Millisecond, s.Items[0].StartAt)
 	assert.Equal(t, 3*time.Second+390*time.Millisecond, s.Items[0].EndAt)
 	assert.Equal(t, "Duration without enclosing space", s.Items[0].Lines[0].String())
+
+	assert.Equal(t, 4*time.Second+609*time.Millisecond, s.Items[1].StartAt)
+	assert.Equal(t, 5*time.Second+985*time.Millisecond, s.Items[1].EndAt)
+	assert.Equal(t, "Duration without colon milliseconds", s.Items[1].Lines[0].String())
 }

--- a/subtitles_internal_test.go
+++ b/subtitles_internal_test.go
@@ -38,6 +38,9 @@ func TestParseDuration(t *testing.T) {
 	d, err = parseDuration("1:23:45.67", ".", 2)
 	assert.NoError(t, err)
 	assert.Equal(t, time.Hour+23*time.Minute+45*time.Second+67*time.Millisecond, d)
+	d, err = parseDuration("1:23:45:67", ":", 2)
+	assert.NoError(t, err)
+	assert.Equal(t, time.Hour+23*time.Minute+45*time.Second+67*time.Millisecond, d)
 }
 
 func TestFormatDuration(t *testing.T) {


### PR DESCRIPTION
This PR allows for the `:` delimiter when parsing milliseconds on srt files.