### PR TITLE
Fix panic when WebVTT cue has missing end time boundary

### DIFF
--- a/webvtt.go
+++ b/webvtt.go
@@ -271,6 +271,10 @@ func ReadFromWebVTT(i io.Reader) (o *Subtitles, err error) {
 
 			// Split line on space to get remaining of time data
 			var right = strings.Fields(left[1])
+			if len(right) == 0 {
+				err = fmt.Errorf("astisub: line %d: missing webvtt end time boundary", lineNum)
+				return
+			}
 
 			// Parse time boundaries
 			if item.StartAt, err = parseDurationWebVTT(left[0]); err != nil {

--- a/webvtt_test.go
+++ b/webvtt_test.go
@@ -266,6 +266,18 @@ func TestWebVTTParseDuration(t *testing.T) {
 	assert.Equal(t, s.Items[1].InlineStyle.WebVTTAlign, "middle")
 }
 
+func TestWebVTTMissingEndTimeBoundary(t *testing.T) {
+	testData := `WEBVTT
+
+1
+00:00:01.000 -->
+Some subtitle text`
+
+	_, err := astisub.ReadFromWebVTT(strings.NewReader(testData))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing webvtt end time boundary")
+}
+
 func TestWebVTTColorToTTML(t *testing.T) {
 	testData := `WEBVTT
 


### PR DESCRIPTION
Previously, parsing a WebVTT line like '00:00:01.000 -->' with no end timestamp panicked with an index out of range error. Now return a descriptive error instead.