### PR TITLE
fix: Panic in ReadFromSRT when cue has missing end time boundary

### DIFF
--- a/srt.go
+++ b/srt.go
@@ -106,6 +106,10 @@ func ReadFromSRT(i io.Reader) (o *Subtitles, err error) {
 			}
 			// We do this to eliminate extra stuff like positions which are not documented anywhere
 			s2 := strings.Fields(s1[1])
+			if len(s2) == 0 {
+				err = fmt.Errorf("astisub: line %d: missing srt end time boundary", lineNum)
+				return
+			}
 
 			// Parse time boundaries
 			if s.StartAt, err = parseDurationSRT(s1[0]); err != nil {

--- a/srt_test.go
+++ b/srt_test.go
@@ -149,6 +149,16 @@ func TestSRTStyled(t *testing.T) {
 	assert.Equal(t, string(c), w.String())
 }
 
+func TestSRTMissingEndTimeBoundary(t *testing.T) {
+	testData := `1
+00:48:52,500 --> 
+Some subtitle text`
+
+	_, err := astisub.ReadFromSRT(strings.NewReader(testData))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing srt end time boundary")
+}
+
 func TestSRTParseDuration(t *testing.T) {
 	testData := `
 	1


### PR DESCRIPTION
## Summary

`ReadFromSRT` panics with `runtime error: index out of range [0] with length 0`
when parsing an SRT cue whose time boundary line is missing the end
timestamp (e.g. `00:00:01,000 --> ` with trailing whitespace, or an
end-time-only-on-next-line malformation).

This is the SRT counterpart of the WebVTT bug fixed in #142. The same
parsing pattern (`strings.Fields(split[1])` followed by an unchecked
`[0]` access) exists in `srt.go` and was not covered by that PR.

## Environment

- go-astisub version: `master` (latest, commit `4c9fa27`)
- Go version: 1.20+
- OS: any (logic bug, platform-independent)

## Steps to Reproduce

```go
package main

import (
    "strings"

    "github.com/asticode/go-astisub"
)

func main() {
    data := `1
00:00:01,000 --> 
Some subtitle text`

    _, _ = astisub.ReadFromSRT(strings.NewReader(data))
}
```

Expected Behavior
ReadFromSRT returns a descriptive error indicating the malformed cue,
allowing the caller to handle the bad input gracefully.
Actual Behavior
The program panics:
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/asticode/go-astisub.ReadFromSRT(...)
        github.com/asticode/go-astisub/srt.go:115
Root Cause
In srt.go, after splitting the time-boundary line on -->, the
right-hand side s1[1] is passed to strings.Fields. When the end
timestamp is missing or whitespace-only, strings.Fields returns an
empty slice, and the subsequent s2[0] access at line 115 panics.
The existing len(s1) < 2 guard at line 103 does not catch this case
because strings.Split produces a 2-element slice
(["00:00:01,000 ", " "]) for an input like "00:00:01,000 --> ".
Triggering Inputs
All of the following cause the panic on current master:
Input	s1 after Split
"00:00:01,000 --> "	["00:00:01,000 ", " "]
"00:00:01,000 -->"	["00:00:01,000 ", ""]
"00:00:01,000 -->\t"	["00:00:01,000 ", "\t"]
" --> "	[" ", " "]
Real-world SRT files exported by some tools occasionally produce such
malformed lines (e.g. when an export is interrupted or when a downstream
tool strips trailing tokens). The library should reject these with a
clear error rather than crash the host application.
Proposed Fix
Add a len(s2) == 0 check immediately after strings.Fields(s1[1]),
returning a descriptive error in the same style as the existing
boundary-parsing errors and as the WebVTT fix in #142:
s2 := strings.Fields(s1[1])
if len(s2) == 0 {
    err = fmt.Errorf("astisub: line %d: missing srt end time boundary", lineNum)
    return
}
Happy to submit a PR mirroring the structure of #142 (4-line guard in
srt.go + a TestSRTMissingEndTimeBoundary test in srt_test.go).

---

## Notes on Filing This

Based on the project conventions audit:

- **PR #142 was merged without a prior issue.** The maintainer accepts PRs directly. Filing this issue is **optional** — many contributors go straight to PR.
- **If you choose to file**: link the resulting PR with `Closes #N` in the PR body so it auto-closes on merge.
- **If you skip the issue**: just open the PR with the description I wrote earlier — that's the path PR #142 took and it was merged in ~24 hours.

My recommendation: **skip the issue, go straight to PR.** The maintainer's behavior on PR #142 (zero-friction merge, friendly response, immediate tag) shows he prefers actionable PRs over discussion issues. The PR description itself contains enough context (reproduction + root cause + fix) to stand alone.

But if you want to file the issue first for documentation/searchability reasons, use the text above as-is.