### PR TITLE
feat: handle srt tags

### DIFF
--- a/srt.go
+++ b/srt.go
@@ -128,6 +128,13 @@ func ReadFromSRT(i io.Reader) (o *Subtitles, err error) {
 			if l := parseTextSrt(line, sa); len(l.Items) > 0 {
 				s.Lines = append(s.Lines, l)
 			}
+
+			// Alignment applies to the whole subtitle and not only to the text
+			// following it, and only its first occurrence is taken into account
+			if sa.SRTPosition != 0 && s.InlineStyle == nil {
+				s.InlineStyle = &StyleAttributes{SRTPosition: sa.SRTPosition}
+				s.InlineStyle.propagateSRTAttributes()
+			}
 		}
 	}
 	return
@@ -190,24 +197,35 @@ func parseTextSrt(i string, sa *StyleAttributes) (o Line) {
 				}
 			}
 		case html.TextToken:
-			if s := strings.TrimSpace(raw); s != "" {
-				// Get style attribute
-				var styleAttributes *StyleAttributes
-				if sa.SRTBold || sa.SRTColor != nil || sa.SRTItalics || sa.SRTUnderline {
-					styleAttributes = &StyleAttributes{
-						SRTBold:      sa.SRTBold,
-						SRTColor:     sa.SRTColor,
-						SRTItalics:   sa.SRTItalics,
-						SRTUnderline: sa.SRTUnderline,
-					}
-					styleAttributes.propagateSRTAttributes()
+			// Override tags such as {\an8} are not part of the srt format but files
+			// ripped from ass subtitles keep them, in which case they must not be
+			// displayed as text. Splitting on them makes sure they only style what
+			// follows them.
+			for _, part := range splitSSAOverrides(raw) {
+				if part.tags != nil {
+					applySRTOverrideTags(sa, part.tags)
+					continue
 				}
 
-				// Append item
-				o.Items = append(o.Items, LineItem{
-					InlineStyle: styleAttributes,
-					Text:        unescapeHTML(raw),
-				})
+				if s := strings.TrimSpace(part.text); s != "" {
+					// Get style attribute
+					var styleAttributes *StyleAttributes
+					if sa.SRTBold || sa.SRTColor != nil || sa.SRTItalics || sa.SRTUnderline {
+						styleAttributes = &StyleAttributes{
+							SRTBold:      sa.SRTBold,
+							SRTColor:     sa.SRTColor,
+							SRTItalics:   sa.SRTItalics,
+							SRTUnderline: sa.SRTUnderline,
+						}
+						styleAttributes.propagateSRTAttributes()
+					}
+
+					// Append item
+					o.Items = append(o.Items, LineItem{
+						InlineStyle: styleAttributes,
+						Text:        unescapeHTML(part.text),
+					})
+				}
 			}
 		}
 	}
@@ -240,6 +258,11 @@ func (s Subtitles) WriteToSRT(o io.Writer) (err error) {
 		c = append(c, bytesSRTTimeBoundariesSeparator...)
 		c = append(c, []byte(formatDurationSRT(v.EndAt))...)
 		c = append(c, bytesLineSeparator...)
+
+		// Add alignment, as an ass override tag since srt has none of its own
+		if v.InlineStyle != nil && v.InlineStyle.SRTPosition != 0 {
+			c = append(c, []byte(fmt.Sprintf(`{\an%d}`, v.InlineStyle.SRTPosition))...)
+		}
 
 		// Loop through lines
 		for _, l := range v.Lines {

--- a/srt_test.go
+++ b/srt_test.go
@@ -149,6 +149,96 @@ func TestSRTStyled(t *testing.T) {
 	assert.Equal(t, string(c), w.String())
 }
 
+func TestSRTOverrideTags(t *testing.T) {
+	testData := `1
+00:00:01,000 --> 00:00:02,000
+{\an8}A sign at the top
+
+2
+00:00:03,000 --> 00:00:04,000
+{\an1}A sign at the {\i1}bottom left
+
+3
+00:00:05,000 --> 00:00:06,000
+{\pos(400,570)}Positioning is dropped
+
+4
+00:00:07,000 --> 00:00:08,000
+Curly {braces} are not tags`
+
+	s, err := astisub.ReadFromSRT(strings.NewReader(testData))
+	require.NoError(t, err)
+	require.Len(t, s.Items, 4)
+
+	// Alignment applies to the whole item
+	assert.Equal(t, "A sign at the top", s.Items[0].Lines[0].String())
+	assert.Equal(t, byte(8), s.Items[0].InlineStyle.SRTPosition)
+	assert.Equal(t, "10%", s.Items[0].InlineStyle.WebVTTLine)
+	assert.Equal(t, "", s.Items[0].InlineStyle.WebVTTAlign)
+	assert.Nil(t, s.Items[0].Lines[0].Items[0].InlineStyle)
+
+	// Text level tags only style what follows them
+	assert.Equal(t, byte(1), s.Items[1].InlineStyle.SRTPosition)
+	assert.Equal(t, "90%", s.Items[1].InlineStyle.WebVTTLine)
+	assert.Equal(t, "left", s.Items[1].InlineStyle.WebVTTAlign)
+	require.Len(t, s.Items[1].Lines[0].Items, 2)
+	assert.Equal(t, "A sign at the ", s.Items[1].Lines[0].Items[0].Text)
+	assert.Nil(t, s.Items[1].Lines[0].Items[0].InlineStyle)
+	assert.Equal(t, "bottom left", s.Items[1].Lines[0].Items[1].Text)
+	assert.True(t, s.Items[1].Lines[0].Items[1].InlineStyle.SRTItalics)
+
+	// Tags that have no equivalent are dropped instead of being displayed
+	assert.Equal(t, "Positioning is dropped", s.Items[2].Lines[0].String())
+	assert.Nil(t, s.Items[2].InlineStyle)
+
+	// Braces are only special when they hold tags
+	assert.Equal(t, "Curly {braces} are not tags", s.Items[3].Lines[0].String())
+
+	// Write to srt
+	w := &bytes.Buffer{}
+	err = s.WriteToSRT(w)
+	assert.NoError(t, err)
+	assert.Equal(t, `1
+00:00:01,000 --> 00:00:02,000
+{\an8}A sign at the top
+
+2
+00:00:03,000 --> 00:00:04,000
+{\an1}A sign at the <i>bottom left</i>
+
+3
+00:00:05,000 --> 00:00:06,000
+Positioning is dropped
+
+4
+00:00:07,000 --> 00:00:08,000
+Curly {braces} are not tags
+`, strings.TrimPrefix(w.String(), string(astisub.BytesBOM)))
+
+	// Write to WebVTT
+	w = &bytes.Buffer{}
+	err = s.WriteToWebVTT(w)
+	assert.NoError(t, err)
+	assert.Equal(t, `WEBVTT
+
+1
+00:00:01.000 --> 00:00:02.000 line:10%
+A sign at the top
+
+2
+00:00:03.000 --> 00:00:04.000 align:left line:90%
+A sign at the <i>bottom left</i>
+
+3
+00:00:05.000 --> 00:00:06.000
+Positioning is dropped
+
+4
+00:00:07.000 --> 00:00:08.000
+Curly {braces} are not tags
+`, w.String())
+}
+
 func TestSRTMissingEndTimeBoundary(t *testing.T) {
 	testData := `1
 00:48:52,500 --> 

--- a/ssa_tags.go
+++ b/ssa_tags.go
@@ -1,0 +1,132 @@
+package astisub
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// http://docs.aegisub.org/latest/ASS_Tags/
+// https://github.com/libass/libass
+
+// Override tags such as {\i1} or {\an8} are not part of the original SubStation Alpha
+// specification: they come from its v4.00+ extension, which has no formal spec and is
+// only documented by the implementations everyone follows: Aegisub and libass. A tag is
+// made of a backslash, a name and its arguments, the arguments being either
+// parenthesized or running until the next tag. Anything else inside the braces is a
+// comment, which is why only the leading number or color of an argument is read:
+// {\i1 this is ignored\b1}.
+
+// SSA override tag regexps
+var (
+	ssaRegexpOverrideBlock  = regexp.MustCompile(`\{\s*\\[^}]*\}`)
+	ssaRegexpOverrideColor  = regexp.MustCompile(`^(&H)?([0-9a-fA-F]+)`)
+	ssaRegexpOverrideNumber = regexp.MustCompile(`^[-+]?[0-9]*\.?[0-9]*`)
+	ssaRegexpOverrideTag    = regexp.MustCompile(`\\([0-9]?[a-zA-Z]+)(\([^)]*\)|[^\\]*)`)
+)
+
+// ssaOverrideTag represents an override tag, e.g. `\an8` gives a tag named "an" with the
+// arguments "8". A digit prefixes the name of the tags selecting one of the four colors,
+// e.g. `\3a`.
+type ssaOverrideTag struct {
+	name string
+	args string
+}
+
+// ssaOverridePart represents a piece of a text, either an override block or literal text
+type ssaOverridePart struct {
+	tags []ssaOverrideTag // set when the part is an override block
+	text string           // set otherwise
+}
+
+// splitSSAOverrides splits a text into its literal parts and its override blocks, the
+// tags of which are parsed
+func splitSSAOverrides(t string) (o []ssaOverridePart) {
+	var previous int
+	for _, idxs := range ssaRegexpOverrideBlock.FindAllStringIndex(t, -1) {
+		if idxs[0] > previous {
+			o = append(o, ssaOverridePart{text: t[previous:idxs[0]]})
+		}
+
+		var tags []ssaOverrideTag
+		for _, m := range ssaRegexpOverrideTag.FindAllStringSubmatch(t[idxs[0]+1:idxs[1]-1], -1) {
+			tags = append(tags, ssaOverrideTag{name: m[1], args: strings.TrimSpace(m[2])})
+		}
+		o = append(o, ssaOverridePart{tags: tags})
+		previous = idxs[1]
+	}
+	if previous < len(t) {
+		o = append(o, ssaOverridePart{text: t[previous:]})
+	}
+	return
+}
+
+// applySRTOverrideTags updates the srt style attributes with the tags. The tags srt
+// cannot represent (positioning, karaoke, animations, fonts, ...) are ignored
+func applySRTOverrideTags(sa *StyleAttributes, tags []ssaOverrideTag) {
+	for _, tag := range tags {
+		switch tag.name {
+		case "r": // reverts every tag
+			*sa = StyleAttributes{}
+		case "a", "an":
+			sa.SRTPosition = ssaOverrideAlignment(tag, sa.SRTPosition)
+		case "b":
+			sa.SRTBold = ssaOverrideBool(tag.args, sa.SRTBold)
+		case "i":
+			sa.SRTItalics = ssaOverrideBool(tag.args, sa.SRTItalics)
+		case "u":
+			sa.SRTUnderline = ssaOverrideBool(tag.args, sa.SRTUnderline)
+		case "c", "1c":
+			sa.SRTColor = ssaOverrideColor(tag.args, sa.SRTColor)
+		}
+	}
+}
+
+// ssaOverrideAlignment parses an `\an8` argument and converts the legacy `\a` layout
+func ssaOverrideAlignment(tag ssaOverrideTag, current byte) byte {
+	v, err := strconv.Atoi(ssaRegexpOverrideNumber.FindString(tag.args))
+	if err != nil {
+		return current
+	}
+	if tag.name == "a" {
+		switch v {
+		case 1, 2, 3: // bottom row, same as the numpad one
+		case 5, 6, 7: // top row, `\a5` is `\an7`
+			v += 2
+		case 9, 10, 11: // middle row, `\a9` is `\an4`
+			v -= 5
+		default:
+			return current
+		}
+	}
+	if v < 1 || v > 9 {
+		return current
+	}
+	return byte(v)
+}
+
+// ssaOverrideBool parses an `\i1` argument, an invalid one leaving the attribute as it is
+func ssaOverrideBool(args string, current bool) bool {
+	v, err := strconv.Atoi(ssaRegexpOverrideNumber.FindString(args))
+	if err != nil {
+		return current
+	}
+	return v != 0
+}
+
+// ssaOverrideColor parses colors being written &Hbbggrr& in hexadecimal or as a plain decimal number
+func ssaOverrideColor(args string, current *Color) *Color {
+	var m = ssaRegexpOverrideColor.FindStringSubmatch(args)
+	if m == nil {
+		return current
+	}
+	var base = 10
+	if m[1] != "" {
+		base = 16
+	}
+	c, err := newColorFromSSAString(m[2], base)
+	if err != nil {
+		return current
+	}
+	return c
+}

--- a/ssa_tags_internal_test.go
+++ b/ssa_tags_internal_test.go
@@ -1,0 +1,114 @@
+package astisub
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitSSAOverrides(t *testing.T) {
+	for _, v := range []struct {
+		expected []ssaOverridePart
+		name     string
+		text     string
+	}{
+		{
+			name:     "no override",
+			text:     "Hello world",
+			expected: []ssaOverridePart{{text: "Hello world"}},
+		},
+		{
+			name: "leading override",
+			text: `{\an8}Hello world`,
+			expected: []ssaOverridePart{
+				{tags: []ssaOverrideTag{{name: "an", args: "8"}}},
+				{text: "Hello world"},
+			},
+		},
+		{
+			name: "in between override",
+			text: `Hello {\i1}world`,
+			expected: []ssaOverridePart{
+				{text: "Hello "},
+				{tags: []ssaOverrideTag{{name: "i", args: "1"}}},
+				{text: "world"},
+			},
+		},
+		{
+			name: "names are not confused with one another",
+			text: `{\an8\a6\b1\bord2\i1\iclip(0,0,1,1)}`,
+			expected: []ssaOverridePart{{tags: []ssaOverrideTag{
+				{name: "an", args: "8"},
+				{name: "a", args: "6"},
+				{name: "b", args: "1"},
+				{name: "bord", args: "2"},
+				{name: "i", args: "1"},
+				{name: "iclip", args: "(0,0,1,1)"},
+			}}},
+		},
+		{
+			name: "color and alpha names keep their digit",
+			text: `{\1c&H0000FF&\3a&HFF&}`,
+			expected: []ssaOverridePart{{tags: []ssaOverrideTag{
+				{name: "1c", args: "&H0000FF&"},
+				{name: "3a", args: "&HFF&"},
+			}}},
+		},
+		{
+			name: "comments are dropped",
+			text: `{\i1 this is a comment}`,
+			expected: []ssaOverridePart{
+				{tags: []ssaOverrideTag{{name: "i", args: "1 this is a comment"}}},
+			},
+		},
+		{
+			name:     "braces without tag are text",
+			text:     "Hello {world}",
+			expected: []ssaOverridePart{{text: "Hello {world}"}},
+		},
+		{
+			name:     "unterminated brace is text",
+			text:     `Hello {\i1 world`,
+			expected: []ssaOverridePart{{text: `Hello {\i1 world`}},
+		},
+	} {
+		t.Run(v.name, func(t *testing.T) {
+			assert.Equal(t, v.expected, splitSSAOverrides(v.text))
+		})
+	}
+}
+
+func TestApplySRTOverrideTags(t *testing.T) {
+	var tags = func(block string) []ssaOverrideTag { return splitSSAOverrides(block)[0].tags }
+
+	var sa = &StyleAttributes{}
+	applySRTOverrideTags(sa, tags(`{\an8\b1\i1\u1\c&H0000FF&}`))
+	assert.Equal(t, byte(8), sa.SRTPosition)
+	assert.True(t, sa.SRTBold)
+	assert.True(t, sa.SRTItalics)
+	assert.True(t, sa.SRTUnderline)
+	assert.Equal(t, &Color{Red: 255}, sa.SRTColor)
+
+	// The tags that srt cannot represent are ignored, including the ones whose name
+	// starts like a supported one
+	applySRTOverrideTags(sa, tags(`{\bord2\iclip(0,0,1,1)\alpha&HFF&\clip(0,0,1,1)\an}`))
+	assert.Equal(t, byte(8), sa.SRTPosition)
+	assert.True(t, sa.SRTBold)
+	assert.True(t, sa.SRTItalics)
+	assert.Equal(t, &Color{Red: 255}, sa.SRTColor)
+
+	applySRTOverrideTags(sa, tags(`{\b0}`))
+	assert.False(t, sa.SRTBold)
+
+	// \r reverts every tag
+	applySRTOverrideTags(sa, tags(`{\r}`))
+	assert.Equal(t, &StyleAttributes{}, sa)
+
+	// The legacy alignment uses another layout
+	applySRTOverrideTags(sa, tags(`{\a6}`))
+	assert.Equal(t, byte(8), sa.SRTPosition)
+	applySRTOverrideTags(sa, tags(`{\a10}`))
+	assert.Equal(t, byte(5), sa.SRTPosition)
+	applySRTOverrideTags(sa, tags(`{\a2}`))
+	assert.Equal(t, byte(2), sa.SRTPosition)
+}

--- a/subtitles.go
+++ b/subtitles.go
@@ -409,28 +409,28 @@ func (sa *StyleAttributes) propagateSRTAttributes() {
 	switch sa.SRTPosition {
 	case 7: // top-left
 		sa.WebVTTAlign = "left"
-		sa.WebVTTPosition = newWebVTTPosition("10%")
+		sa.WebVTTLine = "10%"
 	case 8: // top-center
-		sa.WebVTTPosition = newWebVTTPosition("10%")
+		sa.WebVTTLine = "10%"
 	case 9: // top-right
 		sa.WebVTTAlign = "right"
-		sa.WebVTTPosition = newWebVTTPosition("10%")
+		sa.WebVTTLine = "10%"
 	case 4: // middle-left
 		sa.WebVTTAlign = "left"
-		sa.WebVTTPosition = newWebVTTPosition("50%")
+		sa.WebVTTLine = "50%"
 	case 5: // middle-center
-		sa.WebVTTPosition = newWebVTTPosition("50%")
+		sa.WebVTTLine = "50%"
 	case 6: // middle-right
 		sa.WebVTTAlign = "right"
-		sa.WebVTTPosition = newWebVTTPosition("50%")
+		sa.WebVTTLine = "50%"
 	case 1: // bottom-left
 		sa.WebVTTAlign = "left"
-		sa.WebVTTPosition = newWebVTTPosition("90%")
+		sa.WebVTTLine = "90%"
 	case 2: // bottom-center
-		sa.WebVTTPosition = newWebVTTPosition("90%")
+		sa.WebVTTLine = "90%"
 	case 3: // bottom-right
 		sa.WebVTTAlign = "right"
-		sa.WebVTTPosition = newWebVTTPosition("90%")
+		sa.WebVTTLine = "90%"
 	}
 
 	sa.WebVTTBold = sa.SRTBold


### PR DESCRIPTION
it is very common to have ssa styles embedded in srt subtitles and astisub currently doesn't handle this and leaves tags as is in the output text.

There is no official spec for this but this is widely supported (ffmpeg, vlc, mpv to name a few players that support this). Every implementation follows aegisub's wiki (http://docs.aegisub.org/latest/ASS_Tags/).
See #31 for previous discussion on the subject.

This PR adds support for the most common tags and those that astisub already handled somewhere (positions, bold...). This leaves out tags that can't be processed easily (fonts, move, custom pos and so on). We could add support for those with follow up PRs if wanted but I'm not sure if there's as much value as with those really frequent tags (like position).