### PR TITLE
fix: divide by zero panic in ReadFromSTL on unknown disk format code

### DIFF
--- a/stl.go
+++ b/stl.go
@@ -427,6 +427,7 @@ func parseGSIBlock(b []byte) (g *gsiBlock, err error) {
 		displayStandardCode:       string(bytes.TrimSpace([]byte{b[11]})),
 		editorName:                string(bytes.TrimSpace(b[309:341])),
 		editorContactDetails:      string(bytes.TrimSpace(b[341:373])),
+		framerate:                 25,
 		languageCode:              string(bytes.TrimSpace(b[14:16])),
 		originalEpisodeTitle:      string(bytes.TrimSpace(b[48:80])),
 		originalProgramTitle:      string(bytes.TrimSpace(b[16:48])),
@@ -441,6 +442,8 @@ func parseGSIBlock(b []byte) (g *gsiBlock, err error) {
 	}
 
 	// Framerate
+	// An unknown disk format code leaves the default framerate of 25 in place, which
+	// avoids a division by zero when parsing timecodes.
 	if v, ok := stlFramerateMapping.Get(string(b[3:11])); ok {
 		g.framerate = v.(int)
 	}

--- a/stl_internal_test.go
+++ b/stl_internal_test.go
@@ -1,12 +1,28 @@
 package astisub
 
 import (
+	"bytes"
 	"testing"
 	"time"
 
 	"github.com/asticode/go-astikit"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestSTLUnknownDiskFormatCode(t *testing.T) {
+	// A GSI block whose disk format code is not recognized used to leave the framerate
+	// at 0, which panicked with an integer division by zero when parsing a subsequent
+	// TTI block's timecodes. It now falls back to the default framerate of 25.
+	b := bytes.Repeat([]byte{0x20}, stlBlockSizeGSI)
+	// Valid character code table number (Latin) so parsing reaches timecode handling.
+	b[12] = 0x30
+	b[13] = 0x30
+	copy(b[3:11], []byte("XXXXXXXX")) // unknown disk format code
+	in := append(b, make([]byte, stlBlockSizeTTI)...)
+	assert.NotPanics(t, func() {
+		ReadFromSTL(bytes.NewReader(in), STLOptions{})
+	})
+}
 
 func TestSTLDuration(t *testing.T) {
 	// Default


### PR DESCRIPTION
Reading an STL file whose GSI disk format code is neither `STL25.01` nor `STL30.01` panics with an integer divide by zero, so a malformed subtitle file can crash any caller of `ReadFromSTL`/`OpenFile`.

`parseGSIBlock` only set the framerate when the disk format code matched a known value and otherwise left it at `0`. When the first TTI block is then parsed, `parseDurationSTLBytes` computes `... / framerate` and divides by zero (`parseDurationSTL` on the GSI timecodes has the same problem). This fixes it by returning an error for an unknown disk format code, mirroring how an unknown character code table is already rejected in the same function.

Added a regression test (`TestSTLUnknownDiskFormatCode`) that feeds a GSI block with an unknown disk format code plus a TTI block; it panics before the change and passes after. Valid files still decode identically and the existing tests pass.